### PR TITLE
name rule for debugging purposes

### DIFF
--- a/quax/_core.py
+++ b/quax/_core.py
@@ -55,9 +55,12 @@ def register(primitive: core.Primitive):
             existing_rule = _rules[primitive]  # pyright: ignore
         except KeyError:
 
-            @plum.Dispatcher().abstract
             def existing_rule():
                 assert False
+
+            existing_rule.__name__ = f"{primitive}_dispatcher"
+            existing_rule.__qualname__ = f"{primitive}_dispatcher"
+            existing_rule = plum.Dispatcher().abstract(existing_rule)
 
             _rules[primitive] = existing_rule
         existing_rule.dispatch(rule)


### PR DESCRIPTION
Very cool package!
When I was debugging a trace I found it hard to identify the problematic primitive when the rule was just called `existing_rule`. This PR just renames the rule to identify the relevant primitive.