### PR TITLE
add `__pow__`

### DIFF
--- a/quax/_core.py
+++ b/quax/_core.py
@@ -417,6 +417,7 @@ class ArrayValue(Value):
     __rmul__ = quaxify(_flip_binop(operator.mul))
     __matmul__ = quaxify(operator.matmul)
     __rmatmul__ = quaxify(_flip_binop(operator.matmul))
+    __pow__ = quaxify(operator.pow)
 
     # TODO: add all other methods and properties and things
 

--- a/quax/_core.py
+++ b/quax/_core.py
@@ -418,6 +418,7 @@ class ArrayValue(Value):
     __matmul__ = quaxify(operator.matmul)
     __rmatmul__ = quaxify(_flip_binop(operator.matmul))
     __pow__ = quaxify(operator.pow)
+    __rpow__ = quaxify(_flip_binop(operator.pow))
 
     # TODO: add all other methods and properties and things
 

--- a/quax/zero/_core.py
+++ b/quax/zero/_core.py
@@ -1,5 +1,5 @@
 import functools as ft
-from typing import Any
+from typing import Any, Union
 
 import equinox as eqx
 import jax.core
@@ -150,7 +150,7 @@ def _(lhs: Zero, rhs: Zero, **kwargs) -> Zero:
 
 
 @register(lax.integer_pow_p)
-def _integer_pow(x: Zero, *, y: int) -> Zero | ArrayValue:
+def _integer_pow(x: Zero, *, y: int) -> Union[Zero, ArrayValue]:
     # Zero is a special case, because 0^0 = 1.
     if y == 0:
         return DenseArrayValue(x + 1)  # pyright: ignore

--- a/quax/zero/_core.py
+++ b/quax/zero/_core.py
@@ -147,3 +147,15 @@ def _(lhs: ArrayValue, rhs: Zero, **kwargs) -> Zero:
 @register(lax.dot_general_p)
 def _(lhs: Zero, rhs: Zero, **kwargs) -> Zero:
     return _zero_matmul(lhs, rhs, kwargs)
+
+
+@register(lax.integer_pow_p)
+def _integer_pow(x: Zero, *, y: int) -> Zero | ArrayValue:
+    # Zero is a special case, because 0^0 = 1.
+    if y == 0:
+        return DenseArrayValue(x + 1)  # pyright: ignore
+
+    # Otherwise, we can just return a zero.
+    # Inf and NaN are not integers, so we don't need to worry about them.
+    del y
+    return x

--- a/tests/test_zero.py
+++ b/tests/test_zero.py
@@ -139,7 +139,14 @@ def test_pow():
     assert isinstance(out, quax.zero.Zero)
     assert out.shape == (3, 4)
 
-    # Zero power
+    # Zero power. First check the JAX behaviour.
+    assert jnp.array(0) ** 0 == 1
+    assert jnp.array(0.0) ** 0 == 1
+    assert 0 ** jnp.array(0) == 1
+    assert 0.0 ** jnp.array(0) == 1
+    assert jnp.array(0) ** jnp.array(0) == 1
+    assert jnp.array(0.0) ** jnp.array(0) == 1
+
     out = zero**0
     assert not isinstance(out, quax.zero.Zero)
     ones = jnp.ones((3, 4), jnp.float32)

--- a/tests/test_zero.py
+++ b/tests/test_zero.py
@@ -129,3 +129,32 @@ def test_creation():
         zero = quax.zero.Zero((3, 4), jnp.float32)
         assert eqx.tree_equal(out, zero)
         assert eqx.tree_equal(out2, zero)
+
+
+def test_pow():
+    zero = quax.zero.Zero((3, 4), jnp.float32)
+
+    # Standard power
+    out = zero**3
+    assert isinstance(out, quax.zero.Zero)
+    assert out.shape == (3, 4)
+
+    # Zero power
+    out = zero**0
+    assert not isinstance(out, quax.zero.Zero)
+    ones = jnp.ones((3, 4), jnp.float32)
+    assert jnp.array_equal(out, ones)
+
+    # More complex zero powers
+    out = zero ** jnp.array(0)
+    assert not isinstance(out, quax.zero.Zero)
+    assert jnp.array_equal(out, ones)
+
+    out = zero**zero
+    assert not isinstance(out, quax.zero.Zero)
+    assert jnp.array_equal(out, ones)
+
+    # Reverse power
+    out = 3**zero
+    assert not isinstance(out, quax.zero.Zero)
+    assert jnp.array_equal(out, ones)


### PR DESCRIPTION
DenseArrayValue could be raised to an integer power.

Basic test:
```python
import jax
import jax.numpy as jnp
from quax import DenseArrayValue, quaxify

x = jnp.array([1, 2, 3], dtype=jnp.float64)
DenseArrayValue(x) ** 2
> TypeError: unsupported operand type(s) for ** or pow(): 'DenseArrayValue' and 'int'
```

Fair enough. Looking at `ArrayValue`, there's no `__pow__` defined. If I add that..
```python
class ArrayValue(Value):
    ...
    __add__ = quaxify(operator.add)
    ...
    __pow__ = quaxify(operator.pow)
```

```python
DenseArrayValue(x) ** 2
> Array([1., 4., 9.], dtype=float64)
```
