### PR TITLE
feat: add type annotations

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.4.7
+    rev: v0.5.2
     hooks:
       - id: ruff  # linter
         types_or: [ python, pyi, jupyter ]
@@ -8,7 +8,7 @@ repos:
       - id: ruff-format  # formatter
         types_or: [ python, pyi, jupyter ]
   - repo: https://github.com/RobertCraigie/pyright-python
-    rev: v1.1.365
+    rev: v1.1.372
     hooks:
     - id: pyright
       additional_dependencies: ["equinox", "pytest", "jax", "jaxtyping", "plum-dispatch"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,6 @@ addopts = "--jaxtyping-packages=quax,beartype.beartype(conf=beartype.BeartypeCon
 [tool.ruff.lint]
 select = ["E", "F", "I001"]
 ignore = ["E402", "E721", "E731", "E741", "F722"]
-ignore-init-module-imports = true
 fixable = ["I001", "F401"]
 
 [tool.ruff.lint.isort]

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -89,7 +89,7 @@ def test_double_override():
                 if primitive.multiple_results:
                     return [Foo(x) for x in out]
                 else:
-                    return Foo(out)
+                    return Foo(cast(Array, out))
 
         return Foo
 


### PR DESCRIPTION
From testing v0.0.4 I found that there are some missing type annotations. This PR adds type annotations to `quaxify`, makes `_Quaxify` generic wrt the function, and adds a few miscellaneous types.