### PR TITLE
register lax.cond_p

### DIFF
--- a/quax/_core.py
+++ b/quax/_core.py
@@ -614,19 +614,12 @@ def _(index: ArrayLike, *args: Union[ArrayValue, ArrayLike], branches: tuple):
 
 @register(jax.lax.select_n_p)
 def _(which: ArrayLike, *cases: Union[ArrayValue, ArrayLike]):
-    leaves, _ = jtu.tree_flatten(cases)
-    _, treedef = jtu.tree_flatten(cases[0])
-    out_val = jax.lax.select_n_p.bind(which, *leaves)
-    result = jtu.tree_unflatten(treedef, [out_val])
-    return result
+    return jtu.tree_map(ft.partial(jax.lax.select_n_p.bind, which), *cases)
 
 
 @register(jax.lax.stop_gradient_p)
 def _(x: ArrayValue):
-    leaves, treedef = jtu.tree_flatten(x)
-    out_val = jax.lax.stop_gradient_p.bind(*leaves)
-    result = jtu.tree_unflatten(treedef, [out_val])
-    return result
+    return jtu.tree_map(jax.lax.stop_gradient_p.bind, x)
 
 
 # TODO: also register higher-order primitives like `lax.scan_p` etc.

--- a/quax/_core.py
+++ b/quax/_core.py
@@ -194,7 +194,6 @@ class _QuaxTrace(core.Trace[_QuaxTracer]):
             try:
                 method, _ = rule.resolve_method(values)
             except plum.NotFoundLookupError:
-                print(primitive, values, params)
                 out = _default_process(primitive, values, params)
             else:
                 out = method(*values, **params)

--- a/quax/examples/prng/_core.py
+++ b/quax/examples/prng/_core.py
@@ -1,4 +1,5 @@
 import abc
+import functools as ft
 from collections.abc import Sequence
 from typing import Any, TypeVar
 from typing_extensions import Self, TYPE_CHECKING, TypeAlias
@@ -9,6 +10,7 @@ import jax._src.prng
 import jax.core
 import jax.lax as lax
 import jax.numpy as jnp
+import jax.tree_util as jtu
 import numpy as np
 from jaxtyping import Array, ArrayLike, Float, Integer, UInt, UInt32
 
@@ -159,3 +161,9 @@ def split(key: PRNG_T, num: int = 2) -> Sequence[PRNG_T]:
     """
 
     return key.split(num)
+
+
+# Allows for `jnp.where(pred, key1, key2)`.
+@quax.register(lax.select_n_p)
+def _(pred, *cases: PRNG) -> PRNG:
+    return jtu.tree_map(ft.partial(lax.select_n, pred), *cases)

--- a/quax/examples/prng/_core.py
+++ b/quax/examples/prng/_core.py
@@ -1,5 +1,4 @@
 import abc
-import functools as ft
 from collections.abc import Sequence
 from typing import Any, TypeVar
 from typing_extensions import Self, TYPE_CHECKING, TypeAlias
@@ -10,7 +9,6 @@ import jax._src.prng
 import jax.core
 import jax.lax as lax
 import jax.numpy as jnp
-import jax.tree_util as jtu
 import numpy as np
 from jaxtyping import Array, ArrayLike, Float, Integer, UInt, UInt32
 
@@ -161,9 +159,3 @@ def split(key: PRNG_T, num: int = 2) -> Sequence[PRNG_T]:
     """
 
     return key.split(num)
-
-
-# Allows for `jnp.where(pred, key1, key2)`.
-@quax.register(lax.select_n_p)
-def _(pred, *cases: PRNG) -> PRNG:
-    return jtu.tree_map(ft.partial(lax.select_n, pred), *cases)

--- a/tests/test_cond.py
+++ b/tests/test_cond.py
@@ -78,7 +78,7 @@ def test_cond_grad_closure():
     def outer_fn(
         outer_var: jax.Array,
         dummy: jax.Array,
-        pred: bool | jax.Array,
+        pred: Union[bool, jax.Array],
     ):
         def _true_fn_grad(a: jax.Array):
             return a + outer_var

--- a/tests/test_cond.py
+++ b/tests/test_cond.py
@@ -1,3 +1,5 @@
+from typing import Union
+
 import jax
 import jax.numpy as jnp
 import pytest
@@ -6,7 +8,7 @@ import quax
 from quax.examples.unitful import kilograms, meters, Unitful
 
 
-def _outer_fn(a: jax.Array, b: jax.Array, c: jax.Array, pred: bool | jax.Array):
+def _outer_fn(a: jax.Array, b: jax.Array, c: jax.Array, pred: Union[bool, jax.Array]):
     def _true_fn(a: jax.Array):
         return a + b
 

--- a/tests/test_cond.py
+++ b/tests/test_cond.py
@@ -1,0 +1,109 @@
+import jax
+import jax.numpy as jnp
+import pytest
+
+import quax
+from quax.examples.unitful import kilograms, meters, Unitful
+
+
+def _outer_fn(a: jax.Array, b: jax.Array, c: jax.Array, pred: bool | jax.Array):
+    def _true_fn(a: jax.Array):
+        return a + b
+
+    def _false_fn(a: jax.Array):
+        return a + c
+
+    res = jax.lax.cond(pred, _true_fn, _false_fn, a)
+    return res
+
+
+def test_cond_basic():
+    a = Unitful(jnp.asarray(1.0), {meters: 1})
+    b = Unitful(jnp.asarray(2.0), {meters: 1})
+    c = Unitful(jnp.asarray(10.0), {meters: 1})
+
+    res = quax.quaxify(_outer_fn)(a, b, c, False)
+    assert res.array == 11
+    assert res.units == {meters: 1}
+
+    res = quax.quaxify(_outer_fn)(a, b, c, True)
+    assert res.array == 3
+    assert res.units == {meters: 1}
+
+
+def test_cond_different_units():
+    a = Unitful(jnp.asarray([1.0]), {meters: 1})
+    b = Unitful(jnp.asarray([2.0]), {meters: 1})
+    c = Unitful(jnp.asarray([10.0]), {kilograms: 1})
+
+    with pytest.raises(Exception):
+        quax.quaxify(_outer_fn)(a, b, c, False)
+
+
+def test_cond_jit():
+    a = Unitful(jnp.asarray(1.0), {meters: 1})
+    b = Unitful(jnp.asarray(2.0), {meters: 1})
+    c = Unitful(jnp.asarray(10.0), {meters: 1})
+
+    res = quax.quaxify(jax.jit(_outer_fn))(a, b, c, False)
+    assert res.array == 11
+    assert res.units == {meters: 1}
+
+    res = quax.quaxify(jax.jit(_outer_fn))(a, b, c, True)
+    assert res.array == 3
+    assert res.units == {meters: 1}
+
+
+def test_cond_vmap():
+    a = Unitful(jnp.arange(1), {meters: 1})
+    b = Unitful(jnp.asarray(2), {meters: 1})
+    c = Unitful(jnp.arange(2, 13, 2), {meters: 1})
+    vmap_fn = jax.vmap(_outer_fn, in_axes=(None, None, 0, None))
+
+    res = quax.quaxify(vmap_fn)(a, b, c, True)
+    assert (res.array == a.array + b.array).all()
+    assert res.units == {meters: 1}
+
+    res = quax.quaxify(vmap_fn)(a, b, c, False)
+    assert (res.array.ravel() == a.array.ravel() + c.array.ravel()).all()  # type: ignore
+    assert res.units == {meters: 1}
+
+
+def test_cond_grad_closure():
+    x = Unitful(jnp.asarray(2.0), {meters: 1})
+    b = Unitful(jnp.asarray(2.0), {meters: 1})
+    c = Unitful(jnp.asarray(10.0), {meters: 1})
+    dummy = Unitful(jnp.asarray(1.0), {meters: 1})
+
+    def outer_fn(
+        outer_var: jax.Array,
+        dummy: jax.Array,
+        b: jax.Array,
+        c: jax.Array,
+        pred: bool | jax.Array,
+    ):
+        def _true_fn_grad(outer_var: jax.Array):
+            return outer_var + b
+
+        def _false_fn_grad(outer_var: jax.Array):
+            return outer_var + c
+
+        def _outer_fn_grad(a: jax.Array):
+            return jax.lax.cond(pred, _true_fn_grad, _false_fn_grad, a)
+
+        primals = (outer_var,)
+        tangents = (dummy,)
+        p_out, t_out = jax.jvp(_outer_fn_grad, primals, tangents)
+        return p_out, t_out
+
+    p, t = quax.quaxify(outer_fn)(x, dummy, b, c, True)
+    assert p.array == 4
+    assert p.units == {meters: 1}
+    assert t.array == 1
+    assert t.units == {meters: 1}
+
+    p, t = quax.quaxify(outer_fn)(x, dummy, b, c, False)
+    assert p.array == 12
+    assert p.units == {meters: 1}
+    assert t.array == 1
+    assert t.units == {meters: 1}


### PR DESCRIPTION
Hi!

I'm interested in having additional primitives supported so I started with the `lax.cond_p` one.

This implementation does not support `vmap`ping over the predictor `pred`. In this case, as mentionned in JAX documentation, it falls back to `select`. And it is unclear to me how to support this as there is no primitive for it AFAIU.

It's the first time I'm digging inside JAX internals, so do not hesite to point out any misunderstanding! (For instance, I'm not 100% sure about how I retrieved the tree definition of the outputs).

I will be happy to add support for the scan primitive if / when you're good with that one.
Vadim