### PR TITLE
fix: tracer leaks

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -37,25 +37,27 @@ jobs:
         os: [ ubuntu-latest ]
       fail-fast: false
     runs-on: ${{ matrix.os }}
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+      
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: "**/pyproject.toml"
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
+        run: uv python install ${{ matrix.python-version }}
 
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install -r ./tests/requirements.txt
+      - name: Install the project
+        run: uv sync --group test
 
-      - name: Test with pytest
+      - name: Test package
         run: |
-          python -m pip install .
-          python -m pytest
-  
+          uv run pytest
+
   oldest-supported:
     needs: [format]
     runs-on: ubuntu-latest
@@ -76,7 +78,7 @@ jobs:
 
       - name: Install the project
         run: uv sync --group test --resolution lowest
-      
+
       - name: Test package
         run: >-
           uv run pytest

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -9,7 +9,28 @@ env:
   FORCE_COLOR: 3
 
 jobs:
+  format:
+    name: format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: "**/pyproject.toml"
+
+      - name: "Set up Python"
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Checks with pre-commit
+        uses: pre-commit/action@v2.0.3
+
   run-test:
+    needs: [format]
     strategy:
       matrix:
         python-version: [ "3.10", "3.11", "3.13" ]
@@ -30,15 +51,13 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install -r ./tests/requirements.txt
 
-      - name: Checks with pre-commit
-        uses: pre-commit/action@v2.0.3
-
       - name: Test with pytest
         run: |
           python -m pip install .
           python -m pytest
   
   oldest-supported:
+    needs: [format]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -37,3 +37,27 @@ jobs:
         run: |
           python -m pip install .
           python -m pytest
+  
+  oldest-supported:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: "**/pyproject.toml"
+
+      - name: "Set up Python"
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install the project
+        run: uv sync --group test --resolution lowest
+      
+      - name: Test package
+        run: >-
+          uv run pytest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.2
+    rev: v0.11.0
     hooks:
       - id: ruff  # linter
         types_or: [ python, pyi, jupyter ]
@@ -8,7 +8,7 @@ repos:
       - id: ruff-format  # formatter
         types_or: [ python, pyi, jupyter ]
   - repo: https://github.com/RobertCraigie/pyright-python
-    rev: v1.1.392.post0
+    rev: v1.1.396
     hooks:
     - id: pyright
       additional_dependencies: ["equinox", "pytest", "jax", "jaxtyping", "plum-dispatch"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 ]
 urls = {repository = "https://github.com/patrick-kidger/quax" }
 dependencies = [
-    "jax>=0.4.38",
+    "jax>=0.4.38,<0.5.3",
     "jaxtyping>=0.2.20",
     "equinox>=0.11.0",
     "plum-dispatch>=2.2.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,3 +65,9 @@ include = ["quax", "tests"]
 dev = [
     "pre-commit>=4.1.0",
 ]
+test = [
+    "beartype",
+    "pytest>=8.3.5",
+    "pytest-env>=1.1.5",
+    "jax[cpu]<0.5.3",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 urls = {repository = "https://github.com/patrick-kidger/quax" }
 dependencies = [
     "jax>=0.4.38,<0.5.3",
-    "jaxtyping>=0.2.20",
+    "jaxtyping>=0.2.20,<0.3",
     "equinox>=0.11.0",
     "plum-dispatch>=2.2.1",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "jax>=0.4.38,<0.5.3",
     "jaxtyping>=0.2.20,<0.3",
     "equinox>=0.11.0",
-    "plum-dispatch>=2.2.1",
+    "plum-dispatch>=2.3.0",
 ]
 
 [build-system]
@@ -66,7 +66,7 @@ dev = [
     "pre-commit>=4.1.0",
 ]
 test = [
-    "beartype",
+    "beartype>=0.19.0",
     "pytest>=8.3.5",
     "pytest-env>=1.1.5",
     "jax[cpu]<0.5.3",

--- a/quax/examples/prng/_core.py
+++ b/quax/examples/prng/_core.py
@@ -1,8 +1,7 @@
 import abc
 import functools as ft
 from collections.abc import Sequence
-from typing import Any, TYPE_CHECKING, TypeAlias, TypeVar
-from typing_extensions import Self
+from typing import Any, TypeAlias, TypeVar
 
 import equinox as eqx
 import jax
@@ -20,11 +19,8 @@ import quax
 RealArray: TypeAlias = ArrayLike
 DTypeLikeFloat: TypeAlias = Any
 DTypeLikeInexact: TypeAlias = Any
-if TYPE_CHECKING:
-    SelfPRNG = Self
-else:
-    # beartype+jaxtyping doesn't support Self
-    SelfPRNG = "PRNG"
+
+PRNG_T = TypeVar("PRNG_T", bound="PRNG")
 
 
 class PRNG(quax.ArrayValue):
@@ -41,7 +37,7 @@ class PRNG(quax.ArrayValue):
         """Generate random bits from this PRNG. Must be implemented in subclasses."""
 
     @abc.abstractmethod
-    def split(self, num: int) -> Sequence[SelfPRNG]:
+    def split(self: PRNG_T, num: int) -> Sequence[PRNG_T]:
         """Split this PRNG into multiple sub-PRNGs. Must be implemented in
         subclasses.
         """
@@ -148,9 +144,6 @@ def _normal_real(key, shape, dtype):
     hi = np.array(1.0, dtype)
     u = uniform(key, shape, dtype, lo, hi)
     return lax.mul(np.array(np.sqrt(2), dtype), lax.erf_inv(u))
-
-
-PRNG_T = TypeVar("PRNG_T", bound=PRNG)
 
 
 def split(key: PRNG_T, num: int = 2) -> Sequence[PRNG_T]:

--- a/quax/examples/unitful/_core.py
+++ b/quax/examples/unitful/_core.py
@@ -87,5 +87,6 @@ def _(x: Unitful, y: Unitful, **kwargs):
 
 @quax.register(jax.lax.broadcast_in_dim_p)
 def _(operand: Unitful, **kwargs):
+    kwargs.pop("sharding", None)  # TODO: handle sharding
     new_arr = jax.lax.broadcast_in_dim(operand.array, **kwargs)
     return Unitful(new_arr, operand.units)

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,4 @@
 beartype
-pytest
+pytest>=8.3.5
 pytest-env>=1.1.5
 jax[cpu]

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,4 @@
 beartype
 pytest
-pytest-env
+pytest-env>=1.1.5
 jax[cpu]

--- a/tests/test_lora.py
+++ b/tests/test_lora.py
@@ -124,6 +124,9 @@ def test_regression_38(getkey):
 
     func = quax.quaxify(f)
 
-    # Error type depends on whether jaxtyping is on
-    with pytest.raises((TypeCheckError, NotFoundLookupError)):
+    # Error type depends on whether jaxtyping is on. TypeCheckError is raised
+    # when jaxtyping is on. NotFoundLookupError is raised when jaxtyping is off,
+    # which then kicks over to the default process, which can raise a
+    # RuntimeError if allow_materialise is False.
+    with pytest.raises((TypeCheckError, NotFoundLookupError, RuntimeError)):
         _ = func(y)


### PR DESCRIPTION
This PR is to try for a mergeable fix.
❌: it didn't fix the tracer leak, ✅ does.

This PR starts by adding dependency restrictions / bumps, then upgrading the test suite, then fixing the tracer leak. Doing it in this order shows where the fix comes from.

Setup:
1. restrict Jax to <v0.5.3 since that requires some `_weakref` attribute that isn't on the tracers. We can fix that compatibility issue later. ❌ 
2. fixes for some v0.5.2(?) changes to some of the primitives. This doesn't impact the tracer leak, but is necessary to continue testing. ❌
3. restrict jaxtyping<0.3 since that breaks a named dimension function. We can fix that compatibility issue later. ❌
4. pytest-env>=1.1.5 , pytest>8.3.5. This only affects the testing, not runtime, but it's good to be up-to-date on this stuff. ❌
6. Add test for oldest supported versions. Currently only the newest release of everything is being tested. We want to make sure the fix works on the old stuff as well. ❌
7. Separate format checks from the rest of the test suite. This better separates concerns and reduces redundancy. Also pre-commit checks like pyupgrade should only run on the oldest supported python. ❌
8. Change the test suite to use `uv`. This unifies the CI tests to all use the same `pyproject.toml` dependency group. Only the release test still uses the `tests/requirements.txt`. since the tests still fail, it's not `uv` that's fixing things. ❌
9. Updates pre-commit to see if pyright sees anything re type annotations that can be causing the tracer leaks. I wonder slightly if jax type annotations + beartype could be storing a reference. It is catching something with PRNG annotations, but this doesn't fix things. ❌

<!--
Fix: 
- refactor the Quaxify call to use eqx.Partial.
- refactor the Quaxify call to use an ExitStack.

It appears both fix operations are necessary.
—>