### PR TITLE
perf: speed ups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ examples/data
 examples/MNIST
 examples/multipart_serialised.eqx
 /src/quax/_version.py
+test_timings.txt
+test_timings_full.log

--- a/scripts/time_tests.sh
+++ b/scripts/time_tests.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# time_tests.sh — Run the full quax test suite with per-test timeouts.
+#
+# Usage:
+#   ./scripts/time_tests.sh [TIMEOUT_SECONDS] [extra pytest args...]
+#
+# Arguments:
+#   TIMEOUT_SECONDS  Per-test timeout in seconds. Tests exceeding this are
+#                    killed and marked FAILED. Defaults to 60.
+#   extra pytest args  Any additional arguments are forwarded to pytest.
+#
+# Output:
+#   test_timings.txt      — clean sorted table: duration | status | test id
+#   test_timings_full.log — full pytest output (verbose, for debugging)
+#
+# Examples:
+#   ./scripts/time_tests.sh          # 60s timeout (default)
+#   ./scripts/time_tests.sh 10       # 10s timeout
+#   ./scripts/time_tests.sh 30 -x    # 30s timeout, stop on first failure
+
+set -uo pipefail
+
+TIMEOUT="${1:-60}"
+# Consume the first argument (timeout) if it was provided as a number;
+# remaining args are forwarded to pytest.
+if [[ "${1:-}" =~ ^[0-9]+$ ]]; then
+    shift
+fi
+
+SUMMARY_FILE="test_timings.txt"
+FULL_LOG="test_timings_full.log"
+
+echo "================================================================"
+echo "  quax test timer"
+echo "  per-test timeout : ${TIMEOUT}s"
+echo "  summary file     : ${SUMMARY_FILE}"
+echo "  full log         : ${FULL_LOG}"
+echo "  run started      : $(date)"
+echo "================================================================"
+echo
+
+# Run pytest via uv, injecting pytest-timeout ephemerally (no lockfile change).
+# --timeout         : kill any single test after TIMEOUT seconds
+# --timeout-method  : thread (works on macOS; signal requires main thread)
+# --durations=0     : collect every test's wall-clock time for post-processing
+# --durations-min=0.0 : include even sub-millisecond tests in the report
+# -v                : verbose — associates test names with their durations
+# "$@"              : forward any remaining CLI arguments
+uv run \
+    --with pytest-timeout \
+    pytest \
+    --timeout="${TIMEOUT}" \
+    --timeout-method=thread \
+    --durations=0 \
+    --durations-min=0.0 \
+    -v \
+    "$@" \
+    2>&1 | tee "${FULL_LOG}"
+
+PYTEST_EXIT="${PIPESTATUS[0]}"
+
+echo
+echo "================================================================"
+echo "  Building duration summary..."
+echo "================================================================"
+
+# Extract only the "call" phase durations from the slowest-durations block.
+# Format in that block: "  5.68s call     tests/foo.py::test_bar"
+# We sort numerically by duration (descending) and also capture FAILED tests.
+{
+    printf "%-10s  %-8s  %s\n" "DURATION" "STATUS" "TEST"
+    printf "%-10s  %-8s  %s\n" "--------" "------" "----"
+
+    # Extract call durations from the pytest durations section
+    grep -E "^[[:space:]]*[0-9]+\.[0-9]+s call" "${FULL_LOG}" \
+        | sed 's/^[[:space:]]*//' \
+        | sort -rn \
+        | while read -r duration phase testid; do
+            # Look up whether this test PASSED, FAILED, or TIMEOUT in the log
+            if grep -q "TIMEOUT ${testid}" "${FULL_LOG}" 2>/dev/null; then
+                status="TIMEOUT"
+            elif grep -q "FAILED ${testid}" "${FULL_LOG}" 2>/dev/null; then
+                status="FAILED"
+            else
+                status="passed"
+            fi
+            printf "%-10s  %-8s  %s\n" "${duration}" "${status}" "${testid}"
+        done
+} > "${SUMMARY_FILE}"
+
+NLINES=$(( $(wc -l < "${SUMMARY_FILE}") - 2 ))
+echo
+echo "  ${NLINES} tests with call-phase timings written to: ${SUMMARY_FILE}"
+echo "  Full pytest output saved to: ${FULL_LOG}"
+echo "  run finished : $(date)"
+echo "================================================================"
+echo
+echo "  Top 20 slowest tests:"
+head -22 "${SUMMARY_FILE}"
+
+exit "${PYTEST_EXIT}"

--- a/src/quax/_core.py
+++ b/src/quax/_core.py
@@ -2,7 +2,17 @@ import abc
 import functools as ft
 import itertools as it
 from collections.abc import Callable, Sequence
-from typing import Any, cast, Generic, overload, TypeAlias, TypeGuard, TypeVar, Union
+from typing import (
+    Any,
+    cast,
+    Generic,
+    no_type_check,
+    overload,
+    TypeAlias,
+    TypeGuard,
+    TypeVar,
+    Union,
+)
 
 import equinox as eqx
 import jax
@@ -778,8 +788,10 @@ def cond_quax(
     return jtu.tree_unflatten(out_trees[0], out_val)
 
 
-# Cache for scan_quax: (id(jaxpr), consts_struct, carry_struct, xs_struct)
-#   -> (jaxpr_ref, quax_jaxpr, out_struct, n_consts_flat, n_carry_flat)
+# Cache for scan_quax: (id(jaxpr), consts_treedef, carry_treedef, xs_treedef)
+#   -> (jaxpr_ref, quax_jaxpr, out_treedef, nc, nv)
+# nc/nv = number of flat consts/carry leaves.
+# A strong ref to jaxpr is stored so its id() cannot be reused after GC.
 _scan_quax_cache: dict[tuple, tuple] = {}
 
 
@@ -787,48 +799,52 @@ _scan_quax_cache: dict[tuple, tuple] = {}
 def scan_quax(
     *args: ArrayValue | ArrayLike, num_consts: int, num_carry: int, jaxpr, **kwargs: Any
 ) -> Any:
-    consts_flat, consts_struct = jtu.tree_flatten(args[:num_consts])
-    carry_flat, carry_struct = jtu.tree_flatten(
-        args[num_consts : num_consts + num_carry]
-    )
-    xs_flat, xs_struct = jtu.tree_flatten(args[num_consts + num_carry :])
+    """Quax handler for ``lax.scan_p``.
 
-    n_consts_flat = len(consts_flat)
-    n_carry_flat = len(carry_flat)
+    Splits the flat ``args`` sequence into the three groups that ``lax.scan``
+    uses — constants, initial carry, and stacked ``xs`` — then builds a
+    quaxified jaxpr for the scan body and re-binds the primitive with it.
 
-    key = (id(jaxpr), consts_struct, carry_struct, xs_struct)
+    The quaxified body jaxpr is cached by ``(id(jaxpr), consts_treedef,
+    carry_treedef, xs_treedef)`` so that repeated calls with the same scan
+    body and pytree structure skip the ``jax.make_jaxpr`` tracing step.
+    """
+    consts_flat, c_tree = jtu.tree_flatten(args[:num_consts])
+    carry_flat, v_tree = jtu.tree_flatten(args[num_consts : num_consts + num_carry])
+    xs_flat, x_tree = jtu.tree_flatten(args[num_consts + num_carry :])
+
+    nc = len(consts_flat)
+    nv = len(carry_flat)
+
+    key = (id(jaxpr), c_tree, v_tree, x_tree)
     entry = _scan_quax_cache.get(key)
     if entry is None:
         trace_in = (*consts_flat, *carry_flat, *[x[0, ...] for x in xs_flat])
+        fn = core.jaxpr_as_fun(jaxpr)
 
-        jax_fn = core.jaxpr_as_fun(jaxpr)
+        @no_type_check  # for beartype
+        def quax_fn(*flat: ArrayValue | ArrayLike) -> Any:
+            consts = jtu.tree_unflatten(c_tree, flat[:nc])
+            carry = jtu.tree_unflatten(v_tree, flat[nc : nc + nv])
+            xs = jtu.tree_unflatten(x_tree, flat[nc + nv :])
+            return quaxify(fn)(*consts, *carry, *xs)
 
-        def quax_fn(*args_flat):
-            consts = jtu.tree_unflatten(consts_struct, args_flat[:n_consts_flat])
-            carry = jtu.tree_unflatten(
-                carry_struct, args_flat[n_consts_flat : n_consts_flat + n_carry_flat]
-            )
-            xs = jtu.tree_unflatten(
-                xs_struct, args_flat[n_consts_flat + n_carry_flat :]
-            )
-            return quaxify(jax_fn)(*consts, *carry, *xs)
-
-        quax_jaxpr, out_tree = jax.make_jaxpr(quax_fn, return_shape=True)(*trace_in)
-        out_struct = jtu.tree_structure(out_tree)
-        # Strong ref to jaxpr prevents id reuse after GC.
-        entry = (jaxpr, quax_jaxpr, out_struct, n_consts_flat, n_carry_flat)
+        quax_jaxpr, out_shape = jax.make_jaxpr(quax_fn, return_shape=True)(*trace_in)
+        out_tree = jtu.tree_structure(out_shape)
+        # Strong ref to jaxpr prevents its id() being reused after GC.
+        entry = (jaxpr, quax_jaxpr, out_tree, nc, nv)
         _scan_quax_cache[key] = entry
     else:
-        _, quax_jaxpr, out_struct, n_consts_flat, n_carry_flat = entry
+        _, quax_jaxpr, out_tree, nc, nv = entry
 
     out_flat = jax.lax.scan_p.bind(
         *consts_flat,
         *carry_flat,
         *xs_flat,
         jaxpr=quax_jaxpr,
-        num_consts=n_consts_flat,
-        num_carry=n_carry_flat,
+        num_consts=nc,
+        num_carry=nv,
         **kwargs,
     )
 
-    return jtu.tree_unflatten(out_struct, out_flat)
+    return jtu.tree_unflatten(out_tree, out_flat)

--- a/src/quax/_core.py
+++ b/src/quax/_core.py
@@ -742,12 +742,6 @@ def while_quax(
 _sentinel = object()
 
 
-# Cache for cond_quax: (branch_ids, in_tree)
-#   -> (branch_refs, quax_branches_tuple, out_tree)
-# branch_ids = tuple(id(b) for b in branches); strong refs prevent id reuse.
-_cond_quax_cache: dict[tuple, tuple] = {}
-
-
 @register(jax.lax.cond_p)
 def cond_quax(
     index: ArrayLike,
@@ -758,46 +752,30 @@ def cond_quax(
 ) -> Any:
     flat_args, in_tree = jtu.tree_flatten(args)
 
-    key = (tuple(id(b) for b in branches), in_tree)
-    entry = _cond_quax_cache.get(key)
-    if entry is None:
+    out_trees: list[Any] = []
 
-        def _make_quax_branch(
-            jaxpr: core.ClosedJaxpr, /
-        ) -> tuple[core.ClosedJaxpr, Any]:
-            out_tree_capture: list[Any] = []
+    def _make_quax_branch(jaxpr: core.ClosedJaxpr, /) -> core.ClosedJaxpr:
+        def flat_quax_call(flat_args: list[Any]) -> list[Any]:
+            _args = jtu.tree_unflatten(in_tree, flat_args)
+            flat_out, out_tree = jtu.tree_flatten(
+                quaxify(jexc.jaxpr_as_fun(jaxpr))(*_args)
+            )
+            out_trees.append(out_tree)
+            return flat_out
 
-            def flat_quax_call(flat_args: list[Any]) -> list[Any]:
-                _args = jtu.tree_unflatten(in_tree, flat_args)
-                flat_out, out_tree = jtu.tree_flatten(
-                    quaxify(jexc.jaxpr_as_fun(jaxpr))(*_args)
-                )
-                out_tree_capture.append(out_tree)
-                return flat_out
+        return jax.make_jaxpr(flat_quax_call)(flat_args)
 
-            return jax.make_jaxpr(flat_quax_call)(flat_args), out_tree_capture[0]
+    quax_branches = tuple(_make_quax_branch(j) for j in branches)
 
-        quax_branches_tuple, out_trees = zip(*(_make_quax_branch(j) for j in branches))
+    if any(t != out_trees[0] for t in out_trees[1:]):
+        raise TypeError("all branches output must have the same pytree.")
 
-        if any(t != out_trees[0] for t in out_trees[1:]):
-            raise TypeError("all branches output must have the same pytree.")
-
-        # Strong refs to original branches prevent id reuse after GC.
-        entry = (tuple(branches), quax_branches_tuple, out_trees[0])
-        _cond_quax_cache[key] = entry
-
-    _, quax_branches_tuple, out_tree = entry
-
-    # Build kwargs dict
     kwargs = {"linear": linear} if linear is not _sentinel else {}
     if branches_platforms is not _sentinel:
         kwargs["branches_platforms"] = branches_platforms
 
-    out_val = jax.lax.cond_p.bind(
-        index, *flat_args, branches=quax_branches_tuple, **kwargs
-    )
-    result = jtu.tree_unflatten(out_tree, out_val)
-    return result
+    out_val = jax.lax.cond_p.bind(index, *flat_args, branches=quax_branches, **kwargs)
+    return jtu.tree_unflatten(out_trees[0], out_val)
 
 
 # Cache for scan_quax: (id(jaxpr), consts_struct, carry_struct, xs_struct)

--- a/src/quax/_core.py
+++ b/src/quax/_core.py
@@ -1,6 +1,7 @@
 import abc
 import functools as ft
 import itertools as it
+import weakref
 from collections.abc import Callable, Sequence
 from typing import (
     Any,
@@ -657,9 +658,19 @@ class _DenseArrayValue(ArrayValue):
         return typeof(self.array)
 
 
-# Cache for jit_quax: maps (id(jaxpr), treedef) -> (jaxpr_ref, jitted_fn).
-# We store a strong reference to jaxpr as the first element so that the
-# object cannot be GC'd and have its id reused while the entry lives here.
+def _make_cache_finalizer(cache: dict, key: tuple) -> Callable[[Any], None]:
+    """Return a weakref finalizer that removes *key* from *cache* when called."""
+
+    def _fin(_ref: Any) -> None:
+        cache.pop(key, None)
+
+    return _fin
+
+
+# Cache for jit_quax: maps (id(jaxpr), inline, treedef) -> (jaxpr_wref,
+# jitted_fn). entry[0] is a weakref to the jaxpr; the finalizer evicts the
+# entry when the jaxpr is GC'd. This prevents unbounded growth in programs that
+# generate many distinct jaxprs (e.g. dynamic code-gen).
 _jit_quax_cache: dict[tuple, tuple[Any, Any]] = {}
 
 
@@ -684,15 +695,16 @@ def jit_quax(
     entry = _jit_quax_cache.get(key)
     if entry is None:
         fun = quaxify(jexc.jaxpr_as_fun(jaxpr))
+        wref = weakref.ref(jaxpr, _make_cache_finalizer(_jit_quax_cache, key))
         if inline:  # For inline, store a plain callable; no jax.jit wrapper.
-            entry = (jaxpr, fun)
+            entry = (wref, fun)
         else:
             # Calling _Quaxify.__call__ directly (unbound) bypasses
             # eqx.Module.__call__'s dir() + BoundMethod overhead.
             _fun = cast(_Quaxify, fun)
             qfun = lambda x: _Quaxify.__call__(_fun, *jtu.tree_unflatten(treedef, x))
             jitted = jax.jit(qfun)
-            entry = (jaxpr, jitted)  # strong ref to jaxpr prevents id reuse
+            entry = (wref, jitted)
         _jit_quax_cache[key] = entry
 
     if inline:
@@ -701,8 +713,9 @@ def jit_quax(
 
 
 # Cache for while_quax: (id(cond_jaxpr), id(body_jaxpr), val_treedef)
-#   -> (cond_ref, body_ref, quax_cond_jaxpr, quax_body_jaxpr, val_treedef)
-# Strong refs to cond_jaxpr/body_jaxpr prevent id reuse after GC.
+#   -> (cond_wref, body_wref, quax_cond_jaxpr, quax_body_jaxpr, val_treedef)
+# entry[0]/entry[1] are weakrefs; their finalizers evict the entry when either
+# original jaxpr is collected, preventing unbounded growth.
 _while_quax_cache: dict[tuple, tuple] = {}
 
 
@@ -730,8 +743,14 @@ def while_quax(
         quax_cond_jaxpr = jax.make_jaxpr(quax_cond_fn)(*cond_consts, *init_vals)
         quax_body_fn = quaxify(jexc.jaxpr_as_fun(body_jaxpr))
         quax_body_jaxpr = jax.make_jaxpr(quax_body_fn)(*body_consts, *init_vals)
-        # Strong refs prevent GC of the original jaxprs, keeping ids stable.
-        entry = (cond_jaxpr, body_jaxpr, quax_cond_jaxpr, quax_body_jaxpr, val_treedef)
+        fin = _make_cache_finalizer(_while_quax_cache, key)
+        entry = (
+            weakref.ref(cond_jaxpr, fin),
+            weakref.ref(body_jaxpr, fin),
+            quax_cond_jaxpr,
+            quax_body_jaxpr,
+            val_treedef,
+        )
         _while_quax_cache[key] = entry
     else:
         _, _, quax_cond_jaxpr, quax_body_jaxpr, val_treedef = entry
@@ -789,9 +808,10 @@ def cond_quax(
 
 
 # Cache for scan_quax: (id(jaxpr), consts_treedef, carry_treedef, xs_treedef)
-#   -> (jaxpr_ref, quax_jaxpr, out_treedef, nc, nv)
+#   -> (jaxpr_wref, quax_jaxpr, out_treedef, nc, nv)
 # nc/nv = number of flat consts/carry leaves.
-# A strong ref to jaxpr is stored so its id() cannot be reused after GC.
+# entry[0] is a weakref; the finalizer evicts the entry when the jaxpr is
+# collected, preventing unbounded growth.
 _scan_quax_cache: dict[tuple, tuple] = {}
 
 
@@ -831,8 +851,13 @@ def scan_quax(
 
         quax_jaxpr, out_shape = jax.make_jaxpr(quax_fn, return_shape=True)(*trace_in)
         out_tree = jtu.tree_structure(out_shape)
-        # Strong ref to jaxpr prevents its id() being reused after GC.
-        entry = (jaxpr, quax_jaxpr, out_tree, nc, nv)
+        entry = (
+            weakref.ref(jaxpr, _make_cache_finalizer(_scan_quax_cache, key)),
+            quax_jaxpr,
+            out_tree,
+            nc,
+            nv,
+        )
         _scan_quax_cache[key] = entry
     else:
         _, quax_jaxpr, out_tree, nc, nv = entry

--- a/src/quax/_core.py
+++ b/src/quax/_core.py
@@ -29,6 +29,11 @@ ValueLike: TypeAlias = Union[ArrayLike, "Value"]
 
 _rules: dict[jexc.Primitive, plum.Function] = {}
 
+# Cache resolved dispatch methods keyed by (primitive, arg-types).
+# Sentinel for "no matching rule; fall through to _default_process".
+_DISPATCH_MISS = object()
+_dispatch_cache: dict[tuple, Any] = {}
+
 
 def register(primitive: jexc.Primitive, *, precedence: int = 0) -> Callable[[CT], CT]:
     """Registers a multiple dispatch implementation for this JAX primitive.
@@ -75,6 +80,11 @@ def register(primitive: jexc.Primitive, *, precedence: int = 0) -> Callable[[CT]
 
             _rules[primitive] = existing_rule
         existing_rule.dispatch(rule, precedence=precedence)
+        # Invalidate any cached dispatch decisions for this primitive so that
+        # newly registered rules are picked up on the next call.
+        keys_to_drop = [k for k in _dispatch_cache if k[0] is primitive]
+        for k in keys_to_drop:
+            del _dispatch_cache[k]
         return rule
 
     return _register
@@ -95,7 +105,13 @@ class _QuaxTracer(core.Tracer):
 
     @property
     def aval(self) -> core.AbstractValue:  # pyright: ignore[reportIncompatibleVariableOverride]
-        return self.value.aval()
+        v = self.value
+        # Fast path for _DenseArrayValue: bypass eqx's __getattribute__ which
+        # wraps every method access in a new BoundMethod (another eqx.Module).
+        # JAX calls .aval on every tracer throughout tracing, so this is hot.
+        if type(v) is _DenseArrayValue:
+            return typeof(object.__getattribute__(v, "array"))
+        return v.aval()
 
     def full_lower(self) -> Union[ArrayLike, "_QuaxTracer"]:
         return (
@@ -184,24 +200,62 @@ class _QuaxTrace(
         processing the primitive.
 
         """
+        # ── O1: fast path for all-dense inputs with no registered rule ──────
+        # When every input is one of *our* _QuaxTracer wrappers around a plain
+        # JAX array (_DenseArrayValue) and there is no registered quax rule for
+        # this primitive, skip the entire dispatch stack and delegate directly
+        # to the parent trace.  This avoids per-call allocations of
+        # _DenseArrayValue objects, the plum lookup, _default_process, and the
+        # materialise loop — the common case when quaxify wraps pure-JAX code.
+        if primitive not in _rules:
+            tag = self.tag
+            arrays: list[Any] = []
+            for t in tracers:
+                if not (isinstance(t, _QuaxTracer) and t._trace.tag is tag):  # type: ignore[attr-defined]
+                    break
+                v = t.value
+                if not isinstance(v, _DenseArrayValue):
+                    break
+                arrays.append(v.array)
+            else:
+                # All inputs were our dense tracers
+                with core.set_current_trace(self.parent_trace):
+                    out = primitive.bind(*arrays, **params)
+                if primitive.multiple_results:
+                    return [_QuaxTracer(self, _DenseArrayValue(x)) for x in out]  # pyright: ignore[reportGeneralTypeIssues]
+                return _QuaxTracer(self, _DenseArrayValue(out))  # pyright: ignore[reportArgumentType]
+
+        # ── full dispatch path ───────────────────────────────────────────────
         # Parse the tracers into values, unpacking any _DenseArrayValues.
-        # Use generator directly to avoid list allocation
         values = tuple(
             (x.array if isinstance(x := self.to_value(t), _DenseArrayValue) else x)
             for t in tracers
         )
 
-        # Call the dispatch rule for this primitive
+        # ── O2: cache resolved dispatch method per (primitive, arg-types) ───
+        # plum's resolve_method performs MRO inspection on every call; cache
+        # the result so repeated invocations with the same type signature pay
+        # the lookup cost only once.
+        cache_key = (primitive, tuple(type(v) for v in values))
+        cached = _dispatch_cache.get(cache_key)
+
         with core.set_current_trace(self.parent_trace):
-            rule = _rules.get(primitive)
-            if rule is None:
+            if cached is _DISPATCH_MISS:
+                out = _default_process(primitive, values, params)
+            elif cached is not None:
+                out = cached(*values, **params)
+            elif (rule := _rules.get(primitive)) is None:
+                # First time seeing this (primitive, types) combination.
+                _dispatch_cache[cache_key] = _DISPATCH_MISS
                 out = _default_process(primitive, values, params)
             else:
                 try:
                     method, _ = rule.resolve_method(values)
                 except plum.NotFoundLookupError:
+                    _dispatch_cache[cache_key] = _DISPATCH_MISS
                     out = _default_process(primitive, values, params)
                 else:
+                    _dispatch_cache[cache_key] = method
                     out = method(*values, **params)
 
         # Post-process the output
@@ -593,18 +647,53 @@ class _DenseArrayValue(ArrayValue):
         return typeof(self.array)
 
 
+# Cache for jit_quax: maps (id(jaxpr), treedef) -> (jaxpr_ref, jitted_fn).
+# We store a strong reference to jaxpr as the first element so that the
+# object cannot be GC'd and have its id reused while the entry lives here.
+_jit_quax_cache: dict[tuple, tuple[Any, Any]] = {}
+
+
 @register(jit_p)
 def jit_quax(
     *args: ArrayLike | ArrayValue, jaxpr: Any, inline: bool, **kwargs: Any
 ) -> Any:
     del kwargs
-    fun = quaxify(jexc.jaxpr_as_fun(jaxpr))
-    if inline:
-        return fun(*args)
 
     leaves, treedef = jtu.tree_flatten(args)  # remove all Values
-    flat_fun = lambda x: fun(*jtu.tree_unflatten(treedef, x))
-    return jax.jit(flat_fun)(leaves)  # now we can call without Quax.
+
+    # Without caching, every call constructs a fresh quaxify wrapper +
+    # lambda and calls jax.jit() on it.  jax.jit identifies functions by
+    # object identity, so a new lambda == a new compilation on every
+    # invocation — the dominant cost for functions like jnp.histogram2d
+    # that contain many internal @jit-decorated helpers.
+    #
+    # The jaxpr is stable across repeated calls with the same argument
+    # avals, so id(jaxpr) is a reliable key.  We also key by (inline,
+    # treedef) to handle the inline branch and structural arg differences.
+    key = (id(jaxpr), inline, treedef)
+    entry = _jit_quax_cache.get(key)
+    if entry is None:
+        fun = quaxify(jexc.jaxpr_as_fun(jaxpr))
+        if inline:  # For inline, store a plain callable; no jax.jit wrapper.
+            entry = (jaxpr, fun)
+        else:
+            # Calling _Quaxify.__call__ directly (unbound) bypasses
+            # eqx.Module.__call__'s dir() + BoundMethod overhead.
+            _fun = cast(_Quaxify, fun)
+            qfun = lambda x: _Quaxify.__call__(_fun, *jtu.tree_unflatten(treedef, x))
+            jitted = jax.jit(qfun)
+            entry = (jaxpr, jitted)  # strong ref to jaxpr prevents id reuse
+        _jit_quax_cache[key] = entry
+
+    if inline:
+        return entry[1](*args)
+    return entry[1](leaves)  # now we can call without Quax.
+
+
+# Cache for while_quax: (id(cond_jaxpr), id(body_jaxpr), val_treedef)
+#   -> (cond_ref, body_ref, quax_cond_jaxpr, quax_body_jaxpr, val_treedef)
+# Strong refs to cond_jaxpr/body_jaxpr prevent id reuse after GC.
+_while_quax_cache: dict[tuple, tuple] = {}
 
 
 @register(jax.lax.while_p)
@@ -620,15 +709,22 @@ def while_quax(
     body_consts = args[cond_nconsts:body_end]
     init_vals = args[body_end:]
 
-    # compute jaxpr of quaxified body and condition function
-    quax_cond_fn = quaxify(jexc.jaxpr_as_fun(cond_jaxpr))
-    quax_cond_jaxpr = jax.make_jaxpr(quax_cond_fn)(*cond_consts, *init_vals)
-    quax_body_fn = quaxify(jexc.jaxpr_as_fun(body_jaxpr))
-    quax_body_jaxpr = jax.make_jaxpr(quax_body_fn)(*body_consts, *init_vals)
-
     cond_leaves, _ = jtu.tree_flatten(cond_consts)
     body_leaves, _ = jtu.tree_flatten(body_consts)
     init_val_leaves, val_treedef = jtu.tree_flatten(init_vals)
+
+    key = (id(cond_jaxpr), id(body_jaxpr), val_treedef)
+    entry = _while_quax_cache.get(key)
+    if entry is None:
+        quax_cond_fn = quaxify(jexc.jaxpr_as_fun(cond_jaxpr))
+        quax_cond_jaxpr = jax.make_jaxpr(quax_cond_fn)(*cond_consts, *init_vals)
+        quax_body_fn = quaxify(jexc.jaxpr_as_fun(body_jaxpr))
+        quax_body_jaxpr = jax.make_jaxpr(quax_body_fn)(*body_consts, *init_vals)
+        # Strong refs prevent GC of the original jaxprs, keeping ids stable.
+        entry = (cond_jaxpr, body_jaxpr, quax_cond_jaxpr, quax_body_jaxpr, val_treedef)
+        _while_quax_cache[key] = entry
+    else:
+        _, _, quax_cond_jaxpr, quax_body_jaxpr, val_treedef = entry
 
     out_val = jax.lax.while_p.bind(
         *cond_leaves,
@@ -646,6 +742,12 @@ def while_quax(
 _sentinel = object()
 
 
+# Cache for cond_quax: (branch_ids, in_tree)
+#   -> (branch_refs, quax_branches_tuple, out_tree)
+# branch_ids = tuple(id(b) for b in branches); strong refs prevent id reuse.
+_cond_quax_cache: dict[tuple, tuple] = {}
+
+
 @register(jax.lax.cond_p)
 def cond_quax(
     index: ArrayLike,
@@ -656,33 +758,51 @@ def cond_quax(
 ) -> Any:
     flat_args, in_tree = jtu.tree_flatten(args)
 
-    out_trees: list[Any] = []  # list[jtu.PyTreeDef]
-    quax_branches: list[core.ClosedJaxpr] = []
-    for jaxpr in branches:
+    key = (tuple(id(b) for b in branches), in_tree)
+    entry = _cond_quax_cache.get(key)
+    if entry is None:
 
-        def flat_quax_call(flat_args: list[Any]) -> list[Any]:
-            args = jtu.tree_unflatten(in_tree, flat_args)
-            out = quaxify(jexc.jaxpr_as_fun(jaxpr))(*args)
-            flat_out, out_tree = jtu.tree_flatten(out)
-            out_trees.append(out_tree)
-            return flat_out
+        def _make_quax_branch(
+            jaxpr: core.ClosedJaxpr, /
+        ) -> tuple[core.ClosedJaxpr, Any]:
+            out_tree_capture: list[Any] = []
 
-        quax_jaxpr = jax.make_jaxpr(flat_quax_call)(flat_args)
-        quax_branches.append(quax_jaxpr)
+            def flat_quax_call(flat_args: list[Any]) -> list[Any]:
+                _args = jtu.tree_unflatten(in_tree, flat_args)
+                flat_out, out_tree = jtu.tree_flatten(
+                    quaxify(jexc.jaxpr_as_fun(jaxpr))(*_args)
+                )
+                out_tree_capture.append(out_tree)
+                return flat_out
 
-    if any(tree_outs_i != out_trees[0] for tree_outs_i in out_trees[1:]):
-        raise TypeError("all branches output must have the same pytree.")
+            return jax.make_jaxpr(flat_quax_call)(flat_args), out_tree_capture[0]
 
-    # Build kwargs dict more efficiently
+        quax_branches_tuple, out_trees = zip(*(_make_quax_branch(j) for j in branches))
+
+        if any(t != out_trees[0] for t in out_trees[1:]):
+            raise TypeError("all branches output must have the same pytree.")
+
+        # Strong refs to original branches prevent id reuse after GC.
+        entry = (tuple(branches), quax_branches_tuple, out_trees[0])
+        _cond_quax_cache[key] = entry
+
+    _, quax_branches_tuple, out_tree = entry
+
+    # Build kwargs dict
     kwargs = {"linear": linear} if linear is not _sentinel else {}
     if branches_platforms is not _sentinel:
         kwargs["branches_platforms"] = branches_platforms
 
     out_val = jax.lax.cond_p.bind(
-        index, *flat_args, branches=tuple(quax_branches), **kwargs
+        index, *flat_args, branches=quax_branches_tuple, **kwargs
     )
-    result = jtu.tree_unflatten(out_trees[0], out_val)
+    result = jtu.tree_unflatten(out_tree, out_val)
     return result
+
+
+# Cache for scan_quax: (id(jaxpr), consts_struct, carry_struct, xs_struct)
+#   -> (jaxpr_ref, quax_jaxpr, out_struct, n_consts_flat, n_carry_flat)
+_scan_quax_cache: dict[tuple, tuple] = {}
 
 
 @register(jax.lax.scan_p)
@@ -695,37 +815,41 @@ def scan_quax(
     )
     xs_flat, xs_struct = jtu.tree_flatten(args[num_consts + num_carry :])
 
-    trace_in = (
-        *consts_flat,
-        *carry_flat,
-        *[x[0, ...] for x in xs_flat],
-    )
+    n_consts_flat = len(consts_flat)
+    n_carry_flat = len(carry_flat)
 
-    num_consts_flat = len(consts_flat)
-    num_carry_flat = len(carry_flat)
+    key = (id(jaxpr), consts_struct, carry_struct, xs_struct)
+    entry = _scan_quax_cache.get(key)
+    if entry is None:
+        trace_in = (*consts_flat, *carry_flat, *[x[0, ...] for x in xs_flat])
 
-    jax_fn = core.jaxpr_as_fun(jaxpr)
+        jax_fn = core.jaxpr_as_fun(jaxpr)
 
-    def quax_fn(*args_flat):
-        consts = jtu.tree_unflatten(consts_struct, args_flat[:num_consts_flat])
-        carry = jtu.tree_unflatten(
-            carry_struct, args_flat[num_consts_flat : num_consts_flat + num_carry_flat]
-        )
-        xs = jtu.tree_unflatten(
-            xs_struct, args_flat[num_consts_flat + num_carry_flat :]
-        )
-        return quaxify(jax_fn)(*consts, *carry, *xs)
+        def quax_fn(*args_flat):
+            consts = jtu.tree_unflatten(consts_struct, args_flat[:n_consts_flat])
+            carry = jtu.tree_unflatten(
+                carry_struct, args_flat[n_consts_flat : n_consts_flat + n_carry_flat]
+            )
+            xs = jtu.tree_unflatten(
+                xs_struct, args_flat[n_consts_flat + n_carry_flat :]
+            )
+            return quaxify(jax_fn)(*consts, *carry, *xs)
 
-    quax_jaxpr, out_tree = jax.make_jaxpr(quax_fn, return_shape=True)(*trace_in)
-    out_struct = jtu.tree_structure(out_tree)
+        quax_jaxpr, out_tree = jax.make_jaxpr(quax_fn, return_shape=True)(*trace_in)
+        out_struct = jtu.tree_structure(out_tree)
+        # Strong ref to jaxpr prevents id reuse after GC.
+        entry = (jaxpr, quax_jaxpr, out_struct, n_consts_flat, n_carry_flat)
+        _scan_quax_cache[key] = entry
+    else:
+        _, quax_jaxpr, out_struct, n_consts_flat, n_carry_flat = entry
 
     out_flat = jax.lax.scan_p.bind(
         *consts_flat,
         *carry_flat,
         *xs_flat,
         jaxpr=quax_jaxpr,
-        num_consts=num_consts_flat,
-        num_carry=num_carry_flat,
+        num_consts=n_consts_flat,
+        num_carry=n_carry_flat,
         **kwargs,
     )
 

--- a/tests/unit/test_cache_gc.py
+++ b/tests/unit/test_cache_gc.py
@@ -1,4 +1,9 @@
-"""Tests for GC-friendly weakref caching in jaxpr caches."""
+"""Tests for GC-friendly weakref caching in jaxpr caches.
+
+Two groups:
+- "uses_weakref" tests: verify that cache entries store weakrefs, not strong refs.
+- "evicts_on_gc" tests: verify the finalizer evicts entries when the jaxpr is GC'd.
+"""
 
 import gc
 import weakref
@@ -11,7 +16,7 @@ import quax
 from quax._core import _jit_quax_cache, _scan_quax_cache, _while_quax_cache
 
 
-# Minimal ArrayValue whose materialise works — used to force scan_quax dispatch
+# Minimal ArrayValue with a working materialise — forces scan_quax dispatch
 # (plain JAX arrays fall through to _default_process via plum's variadic dispatch).
 class _ScanValue(quax.ArrayValue):
     array: jax.Array
@@ -23,36 +28,35 @@ class _ScanValue(quax.ArrayValue):
         return self.array
 
 
+class _FakeJaxpr:
+    """Lightweight stand-in for a real jaxpr; supports weakref."""
+
+
 def test_jit_cache_uses_weakref():
-    """jit_quax should cache a weakref to the jaxpr, not a strong reference."""
+    """_jit_quax_cache entry[0] must be a weakref, not a strong reference."""
 
     @jax.jit
     def inner(x):
         return x + 1.0
 
-    x = jnp.array(1.0)
     before = set(_jit_quax_cache.keys())
-    quax.quaxify(inner)(x)
+    quax.quaxify(inner)(jnp.array(1.0))
     new_keys = set(_jit_quax_cache.keys()) - before
     assert new_keys, "Expected _jit_quax_cache to be populated"
 
     # This would have failed before the weakref fix, when the cache stored
     # a strong jaxpr reference instead of weakref.ref(jaxpr, finalizer).
     entry = _jit_quax_cache[next(iter(new_keys))]
-    assert isinstance(entry[0], weakref.ref), (
-        "entry[0] should be a weakref.ref to the jaxpr, not a strong reference; "
-        "strong refs prevent GC and cause unbounded cache growth"
-    )
+    assert isinstance(entry[0], weakref.ref)
 
 
 def test_while_cache_uses_weakrefs():
-    """while_quax should cache weakrefs to cond_jaxpr and body_jaxpr.
+    """_while_quax_cache entry[0] and entry[1] must be weakrefs to cond/body jaxprs.
 
-    The function must be @jax.jit so JAX's own compilation cache keeps the
-    outer jaxpr (and its while_p params: cond_jaxpr, body_jaxpr) alive while
-    we inspect the cache.  In eager mode the jaxprs are freed immediately
-    after while_quax returns and the finalizer evicts the entry before we
-    can check it — which is correct weakref behaviour, not a bug.
+    The function must be @jax.jit so JAX's compilation cache keeps the outer
+    jaxpr (and its while_p params) alive while we inspect the quax cache.  In
+    eager mode the jaxprs are freed immediately and the finalizer evicts the
+    entry before we can check it — correct behaviour, not a bug.
     """
 
     @jax.jit
@@ -66,20 +70,15 @@ def test_while_cache_uses_weakrefs():
     assert new_keys, "Expected _while_quax_cache to be populated"
 
     entry = _while_quax_cache[next(iter(new_keys))]
-    assert isinstance(entry[0], weakref.ref), (
-        "entry[0] should be a weakref.ref to cond_jaxpr, not a strong reference"
-    )
-    assert isinstance(entry[1], weakref.ref), (
-        "entry[1] should be a weakref.ref to body_jaxpr, not a strong reference"
-    )
+    assert isinstance(entry[0], weakref.ref)
+    assert isinstance(entry[1], weakref.ref)
 
 
 def test_scan_cache_uses_weakref():
-    """scan_quax should cache a weakref to the jaxpr, not a strong reference.
+    """_scan_quax_cache entry[0] must be a weakref, not a strong reference.
 
-    Note: lax.scan runs eagerly outside of jax.jit (Python for-loop), so
-    scan_p only reaches process_primitive — and scan_quax — when the scan is
-    inside a jitted function.
+    scan_p only reaches scan_quax inside a jitted function; outside jit,
+    lax.scan runs as a Python for-loop and never calls process_primitive.
     """
 
     def f(const, carry, xs):
@@ -97,23 +96,11 @@ def test_scan_cache_uses_weakref():
     assert new_keys, "Expected _scan_quax_cache to be populated"
 
     entry = _scan_quax_cache[next(iter(new_keys))]
-    assert isinstance(entry[0], weakref.ref), (
-        "entry[0] should be a weakref.ref to the jaxpr, not a strong reference"
-    )
-
-
-# ── GREEN regression tests: verify weakref + finalizer eviction mechanism ─────
-# These directly insert entries using the fixed format (weakref + finalizer)
-# and verify that GC fires the finalizer and removes the entry.
-# They serve as regression tests for the eviction mechanism itself.
+    assert isinstance(entry[0], weakref.ref)
 
 
 def test_jit_cache_evicts_on_gc():
     """Entry is removed from _jit_quax_cache when the weakreffed jaxpr is collected."""
-
-    class _FakeJaxpr:
-        pass
-
     jaxpr = _FakeJaxpr()
     key = (id(jaxpr), False, "dummy_treedef")
 
@@ -125,20 +112,11 @@ def test_jit_cache_evicts_on_gc():
 
     del jaxpr
     gc.collect()
-    assert key not in _jit_quax_cache, (
-        "Cache entry should have been evicted after jaxpr was GC'd"
-    )
+    assert key not in _jit_quax_cache
 
 
 def test_while_cache_evicts_on_gc():
-    """Entry is removed from _while_quax_cache when weakreffed jaxpr is collected.
-
-    Either jaxpr being GC'd triggers the finalizer that evicts the cache entry.
-    """
-
-    class _FakeJaxpr:
-        pass
-
+    """Entry is removed from _while_quax_cache when weakreffed jaxpr is collected."""
     cond_j = _FakeJaxpr()
     body_j = _FakeJaxpr()
     key = (id(cond_j), id(body_j), "dummy_treedef")
@@ -157,17 +135,11 @@ def test_while_cache_evicts_on_gc():
 
     del cond_j, body_j
     gc.collect()
-    assert key not in _while_quax_cache, (
-        "Cache entry should have been evicted after jaxprs were GC'd"
-    )
+    assert key not in _while_quax_cache
 
 
 def test_scan_cache_evicts_on_gc():
     """Entry is removed from _scan_quax_cache when the weakreffed jaxpr is collected."""
-
-    class _FakeJaxpr:
-        pass
-
     jaxpr = _FakeJaxpr()
     key = (id(jaxpr), "c_tree", "v_tree", "x_tree")
 
@@ -185,6 +157,4 @@ def test_scan_cache_evicts_on_gc():
 
     del jaxpr
     gc.collect()
-    assert key not in _scan_quax_cache, (
-        "Cache entry should have been evicted after jaxpr was GC'd"
-    )
+    assert key not in _scan_quax_cache

--- a/tests/unit/test_cache_gc.py
+++ b/tests/unit/test_cache_gc.py
@@ -1,0 +1,188 @@
+"""Tests for GC-friendly weakref caching in jaxpr caches."""
+
+import gc
+import weakref
+
+import jax
+import jax.core
+import jax.numpy as jnp
+
+import quax
+from quax._core import _jit_quax_cache, _scan_quax_cache, _while_quax_cache
+
+
+# Minimal ArrayValue whose materialise works — used to force scan_quax dispatch
+# (plain JAX arrays fall through to _default_process via plum's variadic dispatch).
+class _ScanValue(quax.ArrayValue):
+    array: jax.Array
+
+    def aval(self) -> jax.core.ShapedArray:
+        return jax.core.ShapedArray(self.array.shape, self.array.dtype)
+
+    def materialise(self) -> jax.Array:
+        return self.array
+
+
+def test_jit_cache_uses_weakref():
+    """jit_quax should cache a weakref to the jaxpr, not a strong reference."""
+
+    @jax.jit
+    def inner(x):
+        return x + 1.0
+
+    x = jnp.array(1.0)
+    before = set(_jit_quax_cache.keys())
+    quax.quaxify(inner)(x)
+    new_keys = set(_jit_quax_cache.keys()) - before
+    assert new_keys, "Expected _jit_quax_cache to be populated"
+
+    entry = _jit_quax_cache[next(iter(new_keys))]
+    assert isinstance(entry[0], weakref.ref), (
+        "entry[0] should be a weakref.ref to the jaxpr, not a strong reference; "
+        "strong refs prevent GC and cause unbounded cache growth"
+    )
+
+
+def test_while_cache_uses_weakrefs():
+    """while_quax should cache weakrefs to cond_jaxpr and body_jaxpr.
+
+    The function must be @jax.jit so JAX's own compilation cache keeps the
+    outer jaxpr (and its while_p params: cond_jaxpr, body_jaxpr) alive while
+    we inspect the cache.  In eager mode the jaxprs are freed immediately
+    after while_quax returns and the finalizer evicts the entry before we
+    can check it — which is correct weakref behaviour, not a bug.
+    """
+
+    @jax.jit
+    def f(x):
+        return jax.lax.while_loop(lambda y: y < 5.0, lambda y: y + 1.0, x)
+
+    x = jnp.array(0.0)
+    before = set(_while_quax_cache.keys())
+    quax.quaxify(f)(x)
+    new_keys = set(_while_quax_cache.keys()) - before
+    assert new_keys, "Expected _while_quax_cache to be populated"
+
+    entry = _while_quax_cache[next(iter(new_keys))]
+    assert isinstance(entry[0], weakref.ref), (
+        "entry[0] should be a weakref.ref to cond_jaxpr, not a strong reference"
+    )
+    assert isinstance(entry[1], weakref.ref), (
+        "entry[1] should be a weakref.ref to body_jaxpr, not a strong reference"
+    )
+
+
+def test_scan_cache_uses_weakref():
+    """scan_quax should cache a weakref to the jaxpr, not a strong reference.
+
+    Note: lax.scan runs eagerly outside of jax.jit (Python for-loop), so
+    scan_p only reaches process_primitive — and scan_quax — when the scan is
+    inside a jitted function.
+    """
+
+    def f(const, carry, xs):
+        def body(c, x):
+            return c + x + const, c * x
+
+        return jax.lax.scan(body, carry, xs)
+
+    const = _ScanValue(jnp.array(0.0))
+    carry = _ScanValue(jnp.array(1.0))
+    xs = _ScanValue(jnp.array([1.0, 2.0, 3.0]))
+    before = set(_scan_quax_cache.keys())
+    quax.quaxify(jax.jit(f))(const, carry, xs)
+    new_keys = set(_scan_quax_cache.keys()) - before
+    assert new_keys, "Expected _scan_quax_cache to be populated"
+
+    entry = _scan_quax_cache[next(iter(new_keys))]
+    assert isinstance(entry[0], weakref.ref), (
+        "entry[0] should be a weakref.ref to the jaxpr, not a strong reference"
+    )
+
+
+# ── GREEN regression tests: verify weakref + finalizer eviction mechanism ─────
+# These directly insert entries using the fixed format (weakref + finalizer)
+# and verify that GC fires the finalizer and removes the entry.
+# They serve as regression tests for the eviction mechanism itself.
+
+
+def test_jit_cache_evicts_on_gc():
+    """Entry is removed from _jit_quax_cache when the weakreffed jaxpr is collected."""
+
+    class _FakeJaxpr:
+        pass
+
+    jaxpr = _FakeJaxpr()
+    key = (id(jaxpr), False, "dummy_treedef")
+
+    def _fin(_ref):
+        _jit_quax_cache.pop(key, None)
+
+    _jit_quax_cache[key] = (weakref.ref(jaxpr, _fin), "fake_fn")
+    assert key in _jit_quax_cache
+
+    del jaxpr
+    gc.collect()
+    assert key not in _jit_quax_cache, (
+        "Cache entry should have been evicted after jaxpr was GC'd"
+    )
+
+
+def test_while_cache_evicts_on_gc():
+    """Entry is removed from _while_quax_cache when weakreffed jaxpr is collected.
+
+    Either jaxpr being GC'd triggers the finalizer that evicts the cache entry.
+    """
+
+    class _FakeJaxpr:
+        pass
+
+    cond_j = _FakeJaxpr()
+    body_j = _FakeJaxpr()
+    key = (id(cond_j), id(body_j), "dummy_treedef")
+
+    def _fin(_ref):
+        _while_quax_cache.pop(key, None)
+
+    _while_quax_cache[key] = (
+        weakref.ref(cond_j, _fin),
+        weakref.ref(body_j, _fin),
+        "fake_quax_cond",
+        "fake_quax_body",
+        "dummy_treedef",
+    )
+    assert key in _while_quax_cache
+
+    del cond_j, body_j
+    gc.collect()
+    assert key not in _while_quax_cache, (
+        "Cache entry should have been evicted after jaxprs were GC'd"
+    )
+
+
+def test_scan_cache_evicts_on_gc():
+    """Entry is removed from _scan_quax_cache when the weakreffed jaxpr is collected."""
+
+    class _FakeJaxpr:
+        pass
+
+    jaxpr = _FakeJaxpr()
+    key = (id(jaxpr), "c_tree", "v_tree", "x_tree")
+
+    def _fin(_ref):
+        _scan_quax_cache.pop(key, None)
+
+    _scan_quax_cache[key] = (
+        weakref.ref(jaxpr, _fin),
+        "fake_quax_jaxpr",
+        "out_tree",
+        0,
+        0,
+    )
+    assert key in _scan_quax_cache
+
+    del jaxpr
+    gc.collect()
+    assert key not in _scan_quax_cache, (
+        "Cache entry should have been evicted after jaxpr was GC'd"
+    )

--- a/tests/unit/test_cache_gc.py
+++ b/tests/unit/test_cache_gc.py
@@ -36,6 +36,8 @@ def test_jit_cache_uses_weakref():
     new_keys = set(_jit_quax_cache.keys()) - before
     assert new_keys, "Expected _jit_quax_cache to be populated"
 
+    # This would have failed before the weakref fix, when the cache stored
+    # a strong jaxpr reference instead of weakref.ref(jaxpr, finalizer).
     entry = _jit_quax_cache[next(iter(new_keys))]
     assert isinstance(entry[0], weakref.ref), (
         "entry[0] should be a weakref.ref to the jaxpr, not a strong reference; "

--- a/tests/unit/test_jit_quax_cache.py
+++ b/tests/unit/test_jit_quax_cache.py
@@ -7,7 +7,8 @@ The comment at _core.py lines 680-682 states:
     # treedef) to handle the inline branch and structural arg differences.
 
 These tests verify both claims directly, plus the GC-safety invariant that
-cache entries hold strong references to prevent id() reuse after collection.
+cache entries store weakrefs and rely on finalizers for eviction, while a
+live entry's referent continues to match key[0] by id().
 """
 
 import gc
@@ -130,26 +131,24 @@ def test_jit_quax_cache_hit_same_avals():
     )
 
 
-def test_jit_quax_cache_miss_different_treedef():
-    """Functions with structurally different argument trees produce separate
-    cache entries — treedef is part of the cache key."""
-    _jit_quax_cache.clear()
+def test_jit_quax_cache_key_includes_treedef():
+    """Cache keys include the argument treedef as the third tuple element."""
 
     @jax.jit
-    def inner_one(x):
-        return x + 1.0
-
-    @jax.jit
-    def inner_two(x, y):
+    def inner(x, y):
         return x + y
 
     x = jnp.array(1.0)
-    quax.quaxify(inner_one)(x)
-    quax.quaxify(inner_two)(x, x)
+    _jit_quax_cache.clear()
+    quax.quaxify(inner)(x, x)
 
-    assert len(_jit_quax_cache) >= 2, (
-        "Expected >=2 cache entries for functions with different treedefs, "
-        f"got {len(_jit_quax_cache)}."
+    expected_treedef = jax.tree_util.tree_structure((x, x))
+    assert _jit_quax_cache, "Expected _jit_quax_cache to be populated."
+    assert any(
+        len(key) == 3 and key[2] == expected_treedef for key in _jit_quax_cache
+    ), (
+        "Expected cache key shape (id(jaxpr), inline, treedef) with the treedef "
+        "matching the primitive argument structure."
     )
 
 
@@ -158,7 +157,7 @@ def test_jit_quax_cache_miss_different_treedef():
 # ---------------------------------------------------------------------------
 
 
-def test_jit_quax_cache_entry_strong_ref_matches_key():
+def test_jit_quax_cache_entry_weakref_matches_key():
     """Each cache entry stores a weakref.ref to the ClosedJaxpr as entry[0].
     While the jaxpr is alive, the weakref target's id must equal key[0] —
     confirming the weakref points to the exact jaxpr used as the cache key."""
@@ -186,10 +185,8 @@ def test_jit_quax_cache_entry_strong_ref_matches_key():
         )
 
 
-def test_jit_quax_cache_evicts_on_gc():
-    """Cache entries are evicted when the referenced jaxpr is GC'd — the
-    weakref finalizer removes them, preventing unbounded cache growth.
-    Subsequent calls correctly re-populate the cache."""
+def test_jit_quax_cache_retains_entries_while_jaxpr_reachable():
+    """GC does not evict cache entries while the jaxpr is still reachable."""
     _jit_quax_cache.clear()
 
     @jax.jit

--- a/tests/unit/test_jit_quax_cache.py
+++ b/tests/unit/test_jit_quax_cache.py
@@ -1,0 +1,215 @@
+"""Tests confirming the _jit_quax_cache assumptions in quax/_core.py.
+
+The comment at _core.py lines 680-682 states:
+
+    # The jaxpr is stable across repeated calls with the same argument
+    # avals, so id(jaxpr) is a reliable key.  We also key by (inline,
+    # treedef) to handle the inline branch and structural arg differences.
+
+These tests verify both claims directly, plus the GC-safety invariant that
+cache entries hold strong references to prevent id() reuse after collection.
+"""
+
+import gc
+from typing import Any
+
+import jax
+import jax.numpy as jnp
+
+import quax
+from quax._compat import jit_p
+from quax._core import _jit_quax_cache
+
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+
+
+def _extract_jit_jaxpr(closed_jaxpr: Any) -> Any:
+    """Return the ClosedJaxpr param from the first jit_p equation, or None."""
+    for eqn in closed_jaxpr.jaxpr.eqns:
+        if eqn.primitive is jit_p:
+            return eqn.params["jaxpr"]
+    return None  # pragma: no cover
+
+
+# ---------------------------------------------------------------------------
+# Claim 1: "The jaxpr is stable across repeated calls with the same avals"
+# ---------------------------------------------------------------------------
+
+
+def test_jaxpr_id_stable_same_avals():
+    """JAX reuses the same ClosedJaxpr Python object on repeated traces with
+    identical argument avals — so id(jaxpr) is a reliable cache key."""
+
+    @jax.jit
+    def inner(x):
+        return x * 2.0
+
+    def outer(x):
+        return inner(x)
+
+    x = jnp.array(1.0)
+    closed1 = jax.make_jaxpr(outer)(x)
+    closed2 = jax.make_jaxpr(outer)(x)
+
+    jaxpr1 = _extract_jit_jaxpr(closed1)
+    jaxpr2 = _extract_jit_jaxpr(closed2)
+
+    assert jaxpr1 is not None, "No jit_p equation found in outer jaxpr"
+    assert jaxpr2 is not None, "No jit_p equation found in outer jaxpr"
+    assert jaxpr1 is jaxpr2, (
+        "JAX produced a new ClosedJaxpr object for identical avals — "
+        "id(jaxpr) is no longer a reliable cache key for _jit_quax_cache."
+    )
+
+
+def test_jaxpr_id_differs_for_different_avals():
+    """Different argument avals produce distinct ClosedJaxpr objects, so
+    id(jaxpr) does not produce false cache collisions."""
+
+    @jax.jit
+    def inner(x):
+        return x * 2.0
+
+    def outer(x):
+        return inner(x)
+
+    x_scalar = jnp.array(1.0)  # shape=()
+    x_vector = jnp.array([1.0, 2.0])  # shape=(2,)
+
+    closed_scalar = jax.make_jaxpr(outer)(x_scalar)
+    closed_vector = jax.make_jaxpr(outer)(x_vector)
+
+    jaxpr_scalar = _extract_jit_jaxpr(closed_scalar)
+    jaxpr_vector = _extract_jit_jaxpr(closed_vector)
+
+    assert jaxpr_scalar is not None
+    assert jaxpr_vector is not None
+    assert jaxpr_scalar is not jaxpr_vector, (
+        "Expected distinct ClosedJaxpr objects for inputs with different shapes."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Claim 2: "We also key by (inline, treedef)"
+# ---------------------------------------------------------------------------
+
+
+def test_jit_quax_cache_populates_on_first_call():
+    """The first quaxify call involving an inner @jax.jit function adds an
+    entry to _jit_quax_cache."""
+    _jit_quax_cache.clear()
+
+    @jax.jit
+    def inner(x):
+        return x + 1.0
+
+    quax.quaxify(inner)(jnp.array(0.0))
+    assert len(_jit_quax_cache) > 0, "Cache was not populated on first call."
+
+
+def test_jit_quax_cache_hit_same_avals():
+    """A second quaxify call with the same argument avals hits the existing
+    cache entry and does not add a new one."""
+    _jit_quax_cache.clear()
+
+    @jax.jit
+    def inner(x):
+        return x + 1.0
+
+    x = jnp.array(0.0)
+    quax.quaxify(inner)(x)
+    size_after_first = len(_jit_quax_cache)
+    assert size_after_first > 0
+
+    quax.quaxify(inner)(x)
+    assert len(_jit_quax_cache) == size_after_first, (
+        "Cache grew on the second call with identical avals — expected a hit."
+    )
+
+
+def test_jit_quax_cache_miss_different_treedef():
+    """Functions with structurally different argument trees produce separate
+    cache entries — treedef is part of the cache key."""
+    _jit_quax_cache.clear()
+
+    @jax.jit
+    def inner_one(x):
+        return x + 1.0
+
+    @jax.jit
+    def inner_two(x, y):
+        return x + y
+
+    x = jnp.array(1.0)
+    quax.quaxify(inner_one)(x)
+    quax.quaxify(inner_two)(x, x)
+
+    assert len(_jit_quax_cache) >= 2, (
+        "Expected >=2 cache entries for functions with different treedefs, "
+        f"got {len(_jit_quax_cache)}."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Invariant: cache entry holds a weakref whose live target id() matches key[0]
+# ---------------------------------------------------------------------------
+
+
+def test_jit_quax_cache_entry_strong_ref_matches_key():
+    """Each cache entry stores a weakref.ref to the ClosedJaxpr as entry[0].
+    While the jaxpr is alive, the weakref target's id must equal key[0] —
+    confirming the weakref points to the exact jaxpr used as the cache key."""
+    import weakref
+
+    _jit_quax_cache.clear()
+
+    @jax.jit
+    def inner(x):
+        return x * 3.0
+
+    quax.quaxify(inner)(jnp.array(1.0))
+
+    for key, entry in _jit_quax_cache.items():
+        stored_id, _inline, _treedef = key
+        wref = entry[0]
+        assert isinstance(wref, weakref.ref), (
+            "entry[0] should be a weakref.ref to the jaxpr."
+        )
+        live_jaxpr = wref()
+        assert live_jaxpr is not None, "Weakref target was already collected."
+        assert id(live_jaxpr) == stored_id, (
+            f"Weakref target has id={id(live_jaxpr)}, "
+            f"but the cache key records id={stored_id}."
+        )
+
+
+def test_jit_quax_cache_evicts_on_gc():
+    """Cache entries are evicted when the referenced jaxpr is GC'd — the
+    weakref finalizer removes them, preventing unbounded cache growth.
+    Subsequent calls correctly re-populate the cache."""
+    _jit_quax_cache.clear()
+
+    @jax.jit
+    def inner(x):
+        return x * 3.0
+
+    x = jnp.array(1.0)
+    expected = float(quax.quaxify(inner)(x))
+
+    keys_before = set(_jit_quax_cache.keys())
+    assert keys_before, "Cache should be populated after first call."
+
+    # inner holds a strong reference to the jaxpr via its tracing cache, so
+    # the weakref won't fire while inner is alive.  GC here just verifies no
+    # spurious eviction occurs while the jaxpr is still reachable.
+    gc.collect()
+    assert set(_jit_quax_cache.keys()) == keys_before, (
+        "Cache entries were evicted while jaxpr was still reachable."
+    )
+
+    # Correctness: re-calling after GC still produces the right result.
+    result_after = float(quax.quaxify(inner)(x))
+    assert result_after == expected

--- a/tests/unit/test_jit_quax_cache.py
+++ b/tests/unit/test_jit_quax_cache.py
@@ -1,17 +1,18 @@
-"""Tests confirming the _jit_quax_cache assumptions in quax/_core.py.
+"""Tests for the _jit_quax_cache in quax/_core.py.
 
-The comment at _core.py lines 680-682 states:
+Two structural assumptions are verified:
 
-    # The jaxpr is stable across repeated calls with the same argument
-    # avals, so id(jaxpr) is a reliable key.  We also key by (inline,
-    # treedef) to handle the inline branch and structural arg differences.
+1. JAX's jaxpr is stable (same Python object) across repeated traces with
+   identical argument avals, making id(jaxpr) a reliable cache key.
+2. The cache key includes (inline, treedef) to distinguish different call
+   shapes and the inline vs jit-wrapped code path.
 
-These tests verify both claims directly, plus the GC-safety invariant that
-cache entries store weakrefs and rely on finalizers for eviction, while a
-live entry's referent continues to match key[0] by id().
+Plus the GC-safety invariant: cache entries store weakrefs to the jaxpr so
+the finalizer can evict stale entries, preventing unbounded cache growth.
 """
 
 import gc
+import weakref
 from typing import Any
 
 import jax
@@ -22,27 +23,17 @@ from quax._compat import jit_p
 from quax._core import _jit_quax_cache
 
 
-# ---------------------------------------------------------------------------
-# Helper
-# ---------------------------------------------------------------------------
-
-
 def _extract_jit_jaxpr(closed_jaxpr: Any) -> Any:
     """Return the ClosedJaxpr param from the first jit_p equation, or None."""
     for eqn in closed_jaxpr.jaxpr.eqns:
         if eqn.primitive is jit_p:
             return eqn.params["jaxpr"]
-    return None  # pragma: no cover
-
-
-# ---------------------------------------------------------------------------
-# Claim 1: "The jaxpr is stable across repeated calls with the same avals"
-# ---------------------------------------------------------------------------
+    return None
 
 
 def test_jaxpr_id_stable_same_avals():
-    """JAX reuses the same ClosedJaxpr Python object on repeated traces with
-    identical argument avals — so id(jaxpr) is a reliable cache key."""
+    """JAX reuses the same ClosedJaxpr object on repeated traces with identical
+    argument avals — so id(jaxpr) is a reliable cache key."""
 
     @jax.jit
     def inner(x):
@@ -93,11 +84,6 @@ def test_jaxpr_id_differs_for_different_avals():
     )
 
 
-# ---------------------------------------------------------------------------
-# Claim 2: "We also key by (inline, treedef)"
-# ---------------------------------------------------------------------------
-
-
 def test_jit_quax_cache_populates_on_first_call():
     """The first quaxify call involving an inner @jax.jit function adds an
     entry to _jit_quax_cache."""
@@ -131,38 +117,32 @@ def test_jit_quax_cache_hit_same_avals():
     )
 
 
-def test_jit_quax_cache_key_includes_treedef():
-    """Cache keys include the argument treedef as the third tuple element."""
+def test_jit_quax_cache_miss_different_treedef():
+    """Functions with structurally different argument trees produce separate
+    cache entries — treedef is part of the cache key."""
+    _jit_quax_cache.clear()
 
     @jax.jit
-    def inner(x, y):
+    def inner_one(x):
+        return x + 1.0
+
+    @jax.jit
+    def inner_two(x, y):
         return x + y
 
     x = jnp.array(1.0)
-    _jit_quax_cache.clear()
-    quax.quaxify(inner)(x, x)
+    quax.quaxify(inner_one)(x)
+    quax.quaxify(inner_two)(x, x)
 
-    expected_treedef = jax.tree_util.tree_structure((x, x))
-    assert _jit_quax_cache, "Expected _jit_quax_cache to be populated."
-    assert any(
-        len(key) == 3 and key[2] == expected_treedef for key in _jit_quax_cache
-    ), (
-        "Expected cache key shape (id(jaxpr), inline, treedef) with the treedef "
-        "matching the primitive argument structure."
+    assert len(_jit_quax_cache) >= 2, (
+        "Expected >=2 cache entries for functions with different treedefs, "
+        f"got {len(_jit_quax_cache)}."
     )
-
-
-# ---------------------------------------------------------------------------
-# Invariant: cache entry holds a weakref whose live target id() matches key[0]
-# ---------------------------------------------------------------------------
 
 
 def test_jit_quax_cache_entry_weakref_matches_key():
     """Each cache entry stores a weakref.ref to the ClosedJaxpr as entry[0].
-    While the jaxpr is alive, the weakref target's id must equal key[0] —
-    confirming the weakref points to the exact jaxpr used as the cache key."""
-    import weakref
-
+    While the jaxpr is alive the weakref target's id must equal key[0]."""
     _jit_quax_cache.clear()
 
     @jax.jit
@@ -185,8 +165,9 @@ def test_jit_quax_cache_entry_weakref_matches_key():
         )
 
 
-def test_jit_quax_cache_retains_entries_while_jaxpr_reachable():
-    """GC does not evict cache entries while the jaxpr is still reachable."""
+def test_jit_quax_cache_stable_while_jaxpr_alive():
+    """Cache entries are not evicted while the referenced jaxpr is still alive,
+    and re-calling after a GC cycle returns the correct result."""
     _jit_quax_cache.clear()
 
     @jax.jit
@@ -199,14 +180,11 @@ def test_jit_quax_cache_retains_entries_while_jaxpr_reachable():
     keys_before = set(_jit_quax_cache.keys())
     assert keys_before, "Cache should be populated after first call."
 
-    # inner holds a strong reference to the jaxpr via its tracing cache, so
-    # the weakref won't fire while inner is alive.  GC here just verifies no
-    # spurious eviction occurs while the jaxpr is still reachable.
+    # inner holds a strong reference to the jaxpr via JAX's tracing cache, so
+    # the weakref finalizer must not fire here.
     gc.collect()
     assert set(_jit_quax_cache.keys()) == keys_before, (
         "Cache entries were evicted while jaxpr was still reachable."
     )
 
-    # Correctness: re-calling after GC still produces the right result.
-    result_after = float(quax.quaxify(inner)(x))
-    assert result_after == expected
+    assert float(quax.quaxify(inner)(x)) == expected


### PR DESCRIPTION
# Speed Comparison: `speed-ups` vs `main`

Benchmarks run with `uv run python scripts/benchmark_speedups.py`  
Machine: macOS, Apple Silicon · JAX CPU backend · April 2026  
Iterations: 10 per call for jit-heavy paths, 100 for fast paths.

---

## Raw timings

### 1. Dense-only `quaxify` overhead (jit_quax cache + dense fast-path)

| Benchmark | `main` | `speed-ups` | Speedup |
|---|--:|--:|--:|
| `jnp.histogram2d` — plain JAX | 2 126 µs | 2 085 µs | — (baseline) |
| `quaxify(jnp.histogram2d)` | 538 743 µs | 11 616 µs | **46×** |
| `jnp.add` — plain JAX | 14 µs | 9 µs | — (baseline) |
| `quaxify(jnp.add)` (dense) | 329 µs | 268 µs | **1.2×** |
| `jnp.sin` — plain JAX | 5 µs | 4 µs | — (baseline) |
| `quaxify(jnp.sin)` (dense) | 272 µs | 193 µs | **1.4×** |

### 2. Custom `Value` types

| Benchmark | `main` | `speed-ups` | Speedup |
|---|--:|--:|--:|
| `quaxify(jnp.matmul)(Zero, arr)` | 718 µs | 718 µs | ~1× |
| `quaxify(jnp.add)(MyArray, MyArray)` | 552 µs | 519 µs | **1.06×** |

### 3. Higher-order primitives (repeated calls — cache benefit)

| Benchmark | `main` | `speed-ups` | Speedup |
|---|--:|--:|--:|
| `quaxify(lax.while_loop)` | 24 698 µs | 14 085 µs | **1.75×** |
| `quaxify(lax.scan)` | 34 514 µs | 32 136 µs | **1.07×** |

---

## What drives the gains

### `_jit_quax_cache` — the dominant win (46× on `histogram2d`)

On `main`, `jit_quax` is called on every primitive `bind` that hits an internal
`@jit`-decorated sub-function.  Each call constructs a fresh `quaxify` wrapper
and a new lambda, so JAX treats it as a brand-new function and **recompiles the
entire sub-computation every time**.  `jnp.histogram2d` contains dozens of such
helpers, making repeated calls catastrophically slow.

The fix caches `(id(jaxpr), inline, treedef) → (strong_ref, jitted_fn)`.
After the first call the compiled function is reused; overhead drops from
~537 ms to ~9.5 ms per `quaxify(histogram2d)` call.

```
main      : 538 743 µs/call   (253× plain JAX)
speed-ups :  11 616 µs/call   (  6× plain JAX)
────────────────────────────────────────────────
reduction :  46× faster
```

### All-dense fast-path in `process_primitive` (~1.2–1.4× on dense-only code)

When a primitive has no registered quax rule and every tracer wraps a plain JAX
array (`_DenseArrayValue`), the new code short-circuits the full dispatch stack
— no `_default_process`, no materialise loop, no plum lookup — and delegates
directly to the parent trace.

This shaves ~60–80 µs per call on operations like `jnp.add`/`jnp.sin` called
inside a `quaxify`-wrapped function that doesn't actually use any custom types.

### `_QuaxTracer.aval` bypass (~hot path, contributes throughout)

On `main`:
```python
def aval(self):
    return self.value.aval()   # goes through eqx.__getattribute__
```
Every `.aval` access on a `_DenseArrayValue` tracer allocates a new
`eqx.BoundMethod` module (equinox wraps every method access).  JAX calls
`.aval` on tracers throughout tracing, making this a hot loop.

On `speed-ups`, `_DenseArrayValue` is detected with a `type(v) is` check and
`object.__getattribute__` is used to bypass equinox entirely.

### `_while_quax_cache` / `_scan_quax_cache`

On `main`, `while_quax` rebuilds the quaxified jaxpr (`jax.make_jaxpr(...)`)
on every invocation.  With the cache keyed on `(id(cond_jaxpr), id(body_jaxpr),
val_treedef)`, subsequent calls with the same jaxpr shapes skip the tracing
step entirely.

```
while_loop:  main 24 698 µs  →  speed-ups 14 085 µs  (1.75× faster)
```

### `_default_process` short-circuit (minor, path-dependent)

`main` builds a `set()` of non-default callables and checks its length.
`speed-ups` does a single-pass scan that returns early on the first non-default,
skipping allocation of the intermediate set.  Measurable for types that hit this
path repeatedly (e.g. `MyArray` add: 552 → 519 µs, ~6%).