### PR TITLE
perf: optimize _DenseArrayValue initialization and attribute access

### DIFF
--- a/src/quax/_trace.py
+++ b/src/quax/_trace.py
@@ -37,16 +37,7 @@ class _QuaxTracer(core.Tracer):
         # the resulting shape/dtype must itself be static/immutable; all
         # JAX/equinox transforms return new objects). aval() may still be
         # derived from dynamic jax.Array fields.
-        # For _DenseArrayValue, bypass eqx.__getattribute__ (which allocates a
-        # BoundMethod eqx.Module for every method access) and fetch the array
-        # field directly; tracer construction is on the hot path so this still
-        # saves measurable overhead even though aval() is only called once.
-        if type(value) is _DenseArrayValue:
-            self._cached_aval: core.AbstractValue = typeof(
-                object.__getattribute__(value, "array")
-            )
-        else:
-            self._cached_aval = value.aval()
+        self._cached_aval: core.AbstractValue = value.aval()
 
     @property
     def aval(self) -> core.AbstractValue:  # pyright: ignore[reportIncompatibleVariableOverride]

--- a/src/quax/_values.py
+++ b/src/quax/_values.py
@@ -178,11 +178,33 @@ class _DenseArrayValue(ArrayValue):
 
     array: ArrayLike
 
+    def __init__(self, array: ArrayLike, /) -> None:
+        # Bypass equinox's Module.__setattr__, which on every field assignment
+        # checks whether the module is frozen and performs pytree-leaf
+        # bookkeeping via dataclasses.fields(). _DenseArrayValue is constructed
+        # on every primitive output in the O1 fast path and for every input
+        # passed to to_value(), so this is on the hottest call site in the
+        # trace. The bypass is safe: this class is internal-only, has exactly
+        # one field that is set once at construction and never mutated, and
+        # is never exposed to user code or equinox transforms.
+        object.__setattr__(self, "array", array)
+
     def materialise(self) -> ArrayLike:
         return self.array
 
     def aval(self) -> core.ShapedArray:
         return typeof(self.array)
+
+    def __getattribute__(self, name: str, /) -> Any:
+        # Bypass equinox's Module.__getattribute__, which on every non-magic
+        # attribute access wraps the result in a BoundMethod(func, self) — a
+        # fresh eqx.Module allocation — so that bound methods are themselves
+        # valid pytrees (needed for jax.jit(module.method)). That allocation
+        # is pure overhead here: _DenseArrayValue methods are called directly
+        # by _QuaxTracer and _QuaxTrace internals, never passed to jax.jit.
+        # Benchmarks show .aval() drops from ~38 µs to ~1.6 µs and
+        # .materialise() from ~35 µs to ~0.3 µs with this override.
+        return object.__getattribute__(self, name)
 
 
 def _make_cache_finalizer(cache: dict, key: tuple) -> Callable[[Any], None]:


### PR DESCRIPTION
# `_DenseArrayValue` overhead benchmark

Compares two approaches to reduce equinox `Module` machinery overhead on
`_DenseArrayValue`, the internal wrapper for plain JAX arrays inside a
`_QuaxTrace`.

## Approaches compared

| | `main` | `docs/jitting-notice` |
|---|---|---|
| `_DenseArrayValue` base | plain `eqx.Module` | `eqx.Module` with `__init__` + `__getattribute__` overrides |
| `__init__` | equinox dataclass `__setattr__` (frozen-state check + pytree bookkeeping) | `object.__setattr__` directly |
| `__getattribute__` | equinox's (allocates a `BoundMethod(func, self)` eqx.Module per method call) | `object.__getattribute__` directly |
| `_QuaxTracer.__init__` | special-cases `_DenseArrayValue` — uses `object.__getattribute__(value, "array")` to skip `.aval()` entirely | no special-case; calls `value.aval()` directly (fast via `__getattribute__` override) |

## Environment

```
branch: docs/jitting-notice  /  main
quax:   0.3.1.dev8
jax:    0.8.1
eqx:    0.13.2
platform: CPU (Apple M-series)
```

Script: `scratch/benchmark_dense.py`

## Results

### 1. `_DenseArrayValue` microbenchmarks (no quax trace)

Measures the overrides directly, in isolation from all other quax machinery.

| | `main` (µs) | `feature` (µs) | ratio |
|---|---:|---:|---:|
| `_DenseArrayValue(arr)` — construction | 16.60 | 13.48 | **0.81×** |
| `dense.aval()` | 38.20 | 1.56 | **0.04× (25× faster)** |
| `dense.materialise()` | 35.09 | 0.30 | **0.009× (115× faster)** |
| `dense.array` — field access | 0.35 | 0.13 | **0.38×** |

The dramatic reduction in `.aval()` and `.materialise()` cost confirms the
root cause: equinox's `Module.__getattribute__` allocates a new
`BoundMethod(func, self)` (itself an `eqx.Module`) on every non-magic method
access. The override reduces this to a single `object.__getattribute__` call.

Construction savings (~1.19× faster) come from bypassing equinox's
`Module.__setattr__`, which performs a frozen-state check and pytree-leaf
registration on every field assignment.

### 2. No-JIT, all-dense

`_DenseArrayValue` is constructed for every input and output; `value.aval()`
is called once per tracer construction; `v.array` is accessed in the O1
fast-path loop.

| | `main` (µs) | `feature` (µs) | ratio |
|---|---:|---:|---:|
| `quaxify(jnp.add)(x, x)` — 1 op | 267.49 | 238.61 | **0.89×** |
| `quaxify(chain5)(x)` — 5 ops | 1044.90 | 926.64 | **0.89×** |
| `quaxify(chain20)(x)` — 20 ops | 3931.30 | 3388.75 | **0.86×** |
| `jnp.add(x, x)` — plain baseline | 50.93 | 50.46 | ~equal |
| `chain20(x)` — plain baseline | 1175.86 | 1164.53 | ~equal |

~11–14% improvement, scaling linearly with op count (confirming a per-primitive
fixed cost is being reduced).

### 3. JIT-warm, all-dense

`_DenseArrayValue` construction and `aval()` still run at call time for input
wrapping; the XLA kernel dispatch itself is cached.

| | `main` (µs) | `feature` (µs) | ratio |
|---|---:|---:|---:|
| `quaxify(jit(jnp.add))(x, x)` | 133.06 | 115.82 | **0.87×** |
| `quaxify(jit(chain20))(x)` | 106.66 | 95.16 | **0.89×** |
| `jit(jnp.add)(x, x)` — plain | 4.39 | 4.60 | ~equal (noise) |
| `jit(chain20)(x)` — plain | 10.04 | 5.60 | **0.56×** |

~10–13% improvement even under JIT. The plain-JAX JIT baseline numbers are
within run-to-run noise.

### 4. `Value.default()` / materialise path

A minimal `_TrivialValue` has only `add_p` registered. Calling
`quaxify(jnp.sin)(_TrivialValue)` hits no registered rule and falls through
`Value.default()` → `materialise()`. This tests `_TrivialValue.materialise()`,
not `_DenseArrayValue.materialise()` — dense args are unwrapped to raw arrays
before reaching `Value.default()`.

| | `main` (µs) | `feature` (µs) | ratio |
|---|---:|---:|---:|
| `quaxify(sin)(_TrivialValue)` — materialise path | 298.09 | 314.03 | **1.05× (slight regression)** |
| `quaxify(sin)(dense arr)` — O1 path | 203.96 | 200.99 | ~equal |

The small regression on the materialise path (~5%) occurs because `main`'s
`_QuaxTracer.__init__` special-case also skips `.aval()` for `_DenseArrayValue`
args within the same call. On `docs/jitting-notice` those args pay the (now
cheap) `value.aval()` call via the `__getattribute__` override — still a net
positive overall, but the special-case gave a marginal edge specifically for
mixed-type calls that include dense args.

### 5. Realistic: 10-layer dense linear chain

| | `main` (µs) | `feature` (µs) | ratio |
|---|---:|---:|---:|
| `quaxify(linear_chain)(x)` — no JIT | 5716.42 | 5075.37 | **0.89×** |
| `quaxify(jit(linear_chain))(x)` — JIT warm | 111.21 | 90.60 | **0.82×** |
| `linear_chain(x)` — plain | 281.01 | 239.39 | **0.85×** |
| `jit(linear_chain)(x)` — plain JIT | 9.27 | 6.84 | **0.74×** |

~11–18% improvement across realistic workloads.

## Summary

The `__init__` + `__getattribute__` overrides on `docs/jitting-notice` are
uniformly faster than `main`'s `_QuaxTracer` special-case approach:

- **Micro level**: `.aval()` is 25× faster; `.materialise()` is 115× faster;
  construction is 1.2× faster.
- **Integration level**: 10–15% faster across all measured scenarios.
- **One minor regression**: the forced-materialise mixed-type path is ~5%
  slower — `main`'s broader special-case also covered dense args alongside
  custom types; the feature branch leaves a small gap there.
- **Correctness**: the overrides are safe because `_DenseArrayValue` is an
  internal type never exposed to user code, its fields are set exactly once
  at construction, and the `object.__getattribute__` bypass preserves all
  observable behaviour.

`main`'s special-case was partially effective (only helped `_QuaxTracer.__init__`).
The feature branch approach also accelerates every other call site:
`to_value()`, `_wrap_if_array()`, O1 fast-path `v.array` loop, and any
explicit `dense.materialise()` calls in dispatch rules.
