### PR TITLE
perf: improve function registration and tracing in quaxify

### DIFF
--- a/src/quax/_quaxify.py
+++ b/src/quax/_quaxify.py
@@ -19,6 +19,7 @@ def _partition_and_wrap(tree: Any, filter_spec: Any, trace: _QuaxTrace) -> Any:
     contract:
 
     - ``True``  — all leaves are dynamic (the default for :func:`quaxify`).
+    - ``False`` — no leaves are dynamic; ``tree`` passes through unchanged.
     - A callable or nested bool pytree — only leaves selected by the spec are
       wrapped; the rest are left as plain Python/JAX objects so they pass through
       any nested :func:`quaxify` call unchanged (see the redispatch tutorial).

--- a/src/quax/_quaxify.py
+++ b/src/quax/_quaxify.py
@@ -11,6 +11,34 @@ from ._trace import _QuaxTrace, _unwrap_tracer, _wrap_tracer
 from ._values import _is_value, CT
 
 
+def _partition_and_wrap(tree: Any, filter_spec: Any, trace: _QuaxTrace) -> Any:
+    """Wrap the dynamic leaves of ``tree`` in ``_QuaxTracer`` for the given trace.
+
+    Called once per ``_Quaxify.__call__`` invocation to prepare ``(fn, args,
+    kwargs)`` for dispatch.  ``filter_spec`` mirrors the ``eqx.partition``
+    contract:
+
+    - ``True``  — all leaves are dynamic (the default for :func:`quaxify`).
+    - A callable or nested bool pytree — only leaves selected by the spec are
+      wrapped; the rest are left as plain Python/JAX objects so they pass through
+      any nested :func:`quaxify` call unchanged (see the redispatch tutorial).
+
+    The return value has the same pytree structure as ``tree`` with selected leaves
+    replaced by ``_QuaxTracer`` instances.
+    """
+    if filter_spec is True:
+        # Fast path: every leaf is dynamic, so partition+combine is the identity
+        # transformation. Skip both calls and apply _wrap_tracer in a single
+        # tree_map pass.
+        return jtu.tree_map(ft.partial(_wrap_tracer, trace), tree, is_leaf=_is_value)
+
+    # General path: split tree into dynamic (to be traced) and static (passed
+    # through unchanged), wrap only the dynamic half, then recombine.
+    dynamic, static = eqx.partition(tree, filter_spec, is_leaf=_is_value)
+    dynamic = jtu.tree_map(ft.partial(_wrap_tracer, trace), dynamic, is_leaf=_is_value)
+    return eqx.combine(dynamic, static, is_leaf=_is_value)
+
+
 class _Quaxify(eqx.Module, Generic[CT]):
     fn: CT
     filter_spec: PyTree[bool | Callable[[Any], bool]]
@@ -21,17 +49,12 @@ class _Quaxify(eqx.Module, Generic[CT]):
         return self.fn
 
     def __call__(self, *args: Any, **kwargs: Any) -> Any:
-        dynamic, static = eqx.partition(
-            (self.fn, args, kwargs), self.filter_spec, is_leaf=_is_value
-        )
         tag = core.TraceTag()
         with core.take_current_trace() as parent_trace:
             trace = _QuaxTrace(parent_trace, tag)
-            # Cache partial functions to avoid repeated closure creation
-            dynamic = jtu.tree_map(
-                ft.partial(_wrap_tracer, trace), dynamic, is_leaf=_is_value
+            fn, args, kwargs = _partition_and_wrap(
+                (self.fn, args, kwargs), self.filter_spec, trace
             )
-            fn, args, kwargs = eqx.combine(dynamic, static)
             with core.set_current_trace(trace):
                 out = fn(*args, **kwargs)
             out = jtu.tree_map(ft.partial(_unwrap_tracer, trace), out)


### PR DESCRIPTION
`_Quaxify.__call__` previously called `eqx.partition` + `eqx.combine` on every
invocation, even when `filter_spec=True` (the default).  With `filter_spec=True`
every leaf is dynamic, so partition+combine is the identity transformation —
both calls were pure overhead.

This commit adds `_partition_and_wrap()` with a fast path that replaces the two
calls with a single `jtu.tree_map` when `filter_spec is True`.


## Microbenchmark: `_partition_and_wrap` (isolated)

Tree shape: `(jnp.add, (MyArray, MyArray), {})` — typical `_Quaxify.__call__` input.

| | Before | After | Saving |
|---|--:|--:|--:|
| Full `_partition_and_wrap` call | 96.5 µs | 81.4 µs | **15.2 µs (1.19×)** |
| `eqx.partition(tree, True, ...)` | 9.4 µs | — (eliminated) | 9.4 µs |
| `eqx.combine(dynamic, static, ...)` | ~5–6 µs | — (eliminated) | ~5–6 µs |

The fast path saves one `eqx.partition` + one `eqx.combine` per call to any
`quaxify`-wrapped function when using the default `filter_spec=True`.


## End-to-end benchmarks (eager / no-JIT)

Benchmarks measure total `quaxify(fn)(*args)` wall time across all calling
patterns.  Dominant cost is JAX tracing overhead (~200–500 µs/call), so the
~15 µs saving per `__call__` is a small fraction.

| Benchmark | Before | After | Δ |
|---|--:|--:|--:|
| `quaxify(jnp.histogram2d)` | 11 074 µs | 11 053 µs | — (noise) |
| `quaxify(jnp.add)` — dense | 294 µs | 277 µs | **−17 µs (6%)** |
| `quaxify(jnp.sin)` — dense | 239 µs | 236 µs | — (noise) |
| `quaxify(jnp.matmul)(Zero, arr)` | 896 µs | 722 µs | **−174 µs** |
| `quaxify(jnp.add)(MyArray, MyArray)` | 502 µs | 488 µs | **−14 µs (3%)** |
| `quaxify(lax.while_loop)` | 15 614 µs | 17 730 µs | — (noise) |
| `quaxify(lax.cond)` | 20 883 µs | 20 722 µs | — (noise) |
| `quaxify(lax.scan)` | 36 673 µs | 36 769 µs | — (noise) |

End-to-end measurements have ~5–15% run-to-run variance; only differences
larger than ~30 µs are meaningful.

## Warm-JIT path

Not affected.  On a warm `jax.jit(quaxify(fn))(x, y)` call, JAX dispatches
directly to the compiled XLA kernel and `_Quaxify.__call__` is not entered.
Measured overhead vs plain `jax.jit`: **~4 850 ns**.

