### PR TITLE
Fix TypedX conversion in JAX compatibility layer

### DIFF
--- a/src/quax/__init__.py
+++ b/src/quax/__init__.py
@@ -9,6 +9,9 @@ __all__ = (
 
 import importlib.metadata
 
+# Register JAX compatibility conversions (e.g., TypedInt → Array)
+# These are registered at module import time
+from . import _compat as _compat  # noqa: F401
 from ._dispatch import register as register
 from ._primitives import *  # noqa: F401, F403
 from ._quaxify import quaxify as quaxify

--- a/src/quax/_compat.py
+++ b/src/quax/_compat.py
@@ -3,6 +3,7 @@
 __all__ = (
     "JAX_VERSION",
     # Flags
+    "JAX_GE_0_7_2",
     "JAX_GE_0_9_2",
     "JAX_GE_0_10_1",
     # Features
@@ -16,11 +17,15 @@ from typing import Any, Final
 
 import jax
 import jax.extend.core as jexc
+import jax.numpy as jnp
+import plum
+from jaxtyping import Array
 from packaging.version import Version
 
 
 JAX_VERSION: Final = Version(version("jax"))
 JAX_GE_0_7_0: Final = JAX_VERSION >= Version("0.7.0")
+JAX_GE_0_7_2: Final = JAX_VERSION >= Version("0.7.2")
 JAX_GE_0_8_2: Final = JAX_VERSION >= Version("0.8.2")
 JAX_GE_0_9_2: Final = JAX_VERSION >= Version("0.9.2")
 JAX_GE_0_10_1: Final = JAX_VERSION >= Version("0.10.1")
@@ -36,3 +41,24 @@ if JAX_GE_0_8_2:
     typeof = jax.typeof
 else:
     typeof = jax.core.get_aval  # pyright: ignore[reportAttributeAccessIssue]
+
+
+# Register plum conversions for JAX's typed literal scalars (TypedInt,
+# TypedFloat, TypedComplex). These types were introduced in JAX 0.7.2 to
+# preserve dtype information during canonicalization. They allow any library
+# using quax.ArrayValue to seamlessly handle Python scalars that JAX internally
+# represents as typed literals.
+if JAX_GE_0_7_2:
+    from jax._src import literals as jax_literals
+
+    @plum.conversion_method(type_from=jax_literals.TypedInt, type_to=Array)  # type: ignore[arg-type]
+    @plum.conversion_method(type_from=jax_literals.TypedFloat, type_to=Array)  # type: ignore[arg-type]
+    @plum.conversion_method(type_from=jax_literals.TypedComplex, type_to=Array)  # type: ignore[arg-type]
+    def _typed_int_to_array(obj: Any, /) -> Array:
+        """Convert JAX typed literals to JAX arrays.
+
+        JAX's typed literals carry dtype information through Python scalars.
+        When canonicalizing inputs (e.g., int -> TypedInt), JAX preserves dtype
+        info. This converter extracts that dtype and creates a proper JAX array.
+        """
+        return jnp.asarray(obj, dtype=obj.dtype)

--- a/tests/unit/test_jax_compat.py
+++ b/tests/unit/test_jax_compat.py
@@ -1,0 +1,136 @@
+"""Tests for JAX compatibility features in quax._compat."""
+
+import jax.numpy as jnp
+import numpy as np
+import plum
+import pytest
+
+from quax._compat import JAX_GE_0_7_2
+
+
+# Skip all tests if JAX version doesn't support TypedInt
+pytestmark = pytest.mark.skipif(
+    not JAX_GE_0_7_2, reason="JAX >= 0.7.2 required for TypedInt"
+)
+
+
+@pytest.mark.skipif(not JAX_GE_0_7_2, reason="JAX >= 0.7.2 required")
+def test_typed_int_conversion():
+    """Test that TypedInt can be converted to jax.Array."""
+    from jax._src.literals import TypedInt
+
+    # Create a TypedInt
+    ti = TypedInt(5, np.dtype(np.int32))
+
+    # Convert to Array using plum
+    arr = plum.convert(ti, jnp.ndarray)
+
+    # Verify value and dtype are preserved
+    assert arr.item() == 5
+    assert arr.dtype == np.int32
+
+
+@pytest.mark.skipif(not JAX_GE_0_7_2, reason="JAX >= 0.7.2 required")
+def test_typed_float_conversion():
+    """Test that TypedFloat can be converted to jax.Array."""
+    from jax._src.literals import TypedFloat
+
+    # Create a TypedFloat
+    tf = TypedFloat(3.14, np.dtype(np.float32))
+
+    # Convert to Array using plum
+    arr = plum.convert(tf, jnp.ndarray)
+
+    # Verify value and dtype are preserved
+    assert np.isclose(arr.item(), 3.14, rtol=1e-6)
+    assert arr.dtype == np.float32
+
+
+@pytest.mark.skipif(not JAX_GE_0_7_2, reason="JAX >= 0.7.2 required")
+def test_typed_complex_conversion():
+    """Test that TypedComplex can be converted to jax.Array."""
+    from jax._src.literals import TypedComplex
+
+    # Create a TypedComplex
+    tc = TypedComplex(1 + 2j, np.dtype(np.complex64))
+
+    # Convert to Array using plum
+    arr = plum.convert(tc, jnp.ndarray)
+
+    # Verify value and dtype are preserved
+    assert arr.item() == (1 + 2j)
+    assert arr.dtype == np.complex64
+
+
+@pytest.mark.skipif(not JAX_GE_0_7_2, reason="JAX >= 0.7.2 required")
+def test_typed_int_zero():
+    """Test TypedInt conversion with zero value."""
+    from jax._src.literals import TypedInt
+
+    ti = TypedInt(0, np.dtype(np.int32))
+    arr = plum.convert(ti, jnp.ndarray)
+
+    assert arr.item() == 0
+    assert arr.dtype == np.int32
+
+
+@pytest.mark.skipif(not JAX_GE_0_7_2, reason="JAX >= 0.7.2 required")
+def test_typed_float_negative():
+    """Test TypedFloat conversion with negative value."""
+    from jax._src.literals import TypedFloat
+
+    tf = TypedFloat(-2.5, np.dtype(np.float32))
+    arr = plum.convert(tf, jnp.ndarray)
+
+    assert np.isclose(arr.item(), -2.5, rtol=1e-6)
+    assert arr.dtype == np.float32
+
+
+@pytest.mark.skipif(not JAX_GE_0_7_2, reason="JAX >= 0.7.2 required")
+def test_typed_complex_zero():
+    """Test TypedComplex conversion with zero value."""
+    from jax._src.literals import TypedComplex
+
+    tc = TypedComplex(0j, np.dtype(np.complex64))
+    arr = plum.convert(tc, jnp.ndarray)
+
+    assert arr.item() == 0j
+    assert arr.dtype == np.complex64
+
+
+@pytest.mark.skipif(not JAX_GE_0_7_2, reason="JAX >= 0.7.2 required")
+def test_typed_int_large_value():
+    """Test TypedInt conversion with large value that fits in int32."""
+    from jax._src.literals import TypedInt
+
+    # Use a value that fits in int32 (max int32 is 2^31 - 1)
+    ti = TypedInt(2**30, np.dtype(np.int32))
+    arr = plum.convert(ti, jnp.ndarray)
+
+    assert arr.item() == 2**30
+    assert arr.dtype == np.int32
+
+
+@pytest.mark.skipif(not JAX_GE_0_7_2, reason="JAX >= 0.7.2 required")
+def test_typed_float_precision():
+    """Test TypedFloat conversion preserves precision for float32."""
+    from jax._src.literals import TypedFloat
+
+    tf = TypedFloat(1.23456789, np.dtype(np.float32))
+    arr = plum.convert(tf, jnp.ndarray)
+
+    # float32 has ~7 decimal digits of precision
+    assert np.isclose(arr.item(), 1.23456789, rtol=1e-6)
+    assert arr.dtype == np.float32
+
+
+@pytest.mark.skipif(not JAX_GE_0_7_2, reason="JAX >= 0.7.2 required")
+def test_typed_complex_with_imaginary():
+    """Test TypedComplex conversion with pure imaginary number."""
+    from jax._src.literals import TypedComplex
+
+    tc = TypedComplex(3j, np.dtype(np.complex64))
+    arr = plum.convert(tc, jnp.ndarray)
+
+    assert arr.item() == 3j
+    assert arr.dtype == np.complex64


### PR DESCRIPTION
JAX v10.something can internally cast types like an int to a TypedInt. Then `jnp.array` doesn't always turn that into an array, which can break quax.
We register some conversions so that plum-related dispatches will correctly cast these typed aliases to arrays automatically.
E.g.,
```
@plum.dispatch
def func(x) -> Array:
    return jnp.asarray(x)
```

before `func(1)` can return `TypedInt` under certain circumstances. Now it always returns `jax.Array`.