### PR TITLE
perf: mark jax.Array faithful to re-enable plum dispatch caching

### DIFF
--- a/src/quax/_compat.py
+++ b/src/quax/_compat.py
@@ -45,6 +45,28 @@ else:
     typeof = jax.core.get_aval  # pyright: ignore[reportAttributeAccessIssue]
 
 
+# Mark `jax.Array` as "faithful" for `plum` multiple dispatch.
+#
+# `plum` caches method resolution keyed on the *types* of the arguments, but
+# only when every type registered on a function is "faithful" -- i.e. when
+# ``isinstance(x, T)`` agrees with ``issubclass(type(x), T)``, so that the type
+# alone determines dispatch. Newer JAX gives `jax.Array` a custom metaclass
+# ``__instancecheck__``, so `plum` conservatively treats it as non-faithful.
+#
+# A single non-faithful type on a `plum` function disables its resolution cache
+# entirely. Because `quax` registers ``convert`` methods targeting `jax.Array`
+# (below), and `plum` runs ``convert`` on the return value of every dispatched
+# function with a concrete return annotation, that uncached resolution is re-run
+# on every such call -- a large, easily-avoided cost for any library built on
+# `quax.ArrayValue`.
+#
+# Setting ``__faithful__`` re-enables the cache. It only gates *caching* of
+# `plum`'s deterministic, type-based resolution; it never changes which method
+# is selected, so results are unchanged. This must run before the ``convert``
+# methods below are registered, so their signatures are built faithful.
+jax.Array.__faithful__ = True  # type: ignore[attr-defined]
+
+
 # Register plum conversions for JAX's typed literal scalars (TypedInt,
 # TypedFloat, TypedComplex). These types were introduced in JAX 0.7.2 to
 # preserve dtype information during canonicalization. They allow any library

--- a/tests/unit/test_jax_compat.py
+++ b/tests/unit/test_jax_compat.py
@@ -1,11 +1,12 @@
 """Tests for JAX compatibility features in quax._compat."""
 
+import importlib
+
 import jax
 import jax.numpy as jnp
 import numpy as np
 import plum
 import pytest
-from plum.type import is_faithful
 
 from quax._compat import JAX_GE_0_7_2
 
@@ -149,19 +150,26 @@ def test_typed_complex_with_imaginary():
 # function. These tests guard against that regression.
 
 
+def _plum_attr(candidates, attr):
+    """Fetch a plum attribute whose private module path varies across versions."""
+    for modname in candidates:
+        try:
+            return getattr(importlib.import_module(modname), attr)
+        except (ImportError, AttributeError):  # pragma: no cover
+            continue
+    pytest.skip(f"plum.{attr} is not importable in this plum version")
+
+
 def test_jax_array_marked_faithful():
     """`quax._compat` marks `jax.Array` faithful, and `plum` recognises it."""
     assert getattr(jax.Array, "__faithful__", False) is True
+    is_faithful = _plum_attr(("plum.type", "plum._type"), "is_faithful")
     assert is_faithful(jax.Array) is True
 
 
 def _convert_dispatcher():
     """Return plum's internal ``convert`` dispatcher, or skip if relocated."""
-    try:
-        from plum.promotion import _convert
-    except ImportError:  # pragma: no cover - guards against plum internals moving
-        pytest.skip("plum's internal convert dispatcher is not importable")
-    return _convert
+    return _plum_attr(("plum.promotion", "plum._promotion"), "_convert")
 
 
 def test_convert_resolver_stays_faithful():

--- a/tests/unit/test_jax_compat.py
+++ b/tests/unit/test_jax_compat.py
@@ -1,9 +1,11 @@
 """Tests for JAX compatibility features in quax._compat."""
 
+import jax
 import jax.numpy as jnp
 import numpy as np
 import plum
 import pytest
+from plum.type import is_faithful
 
 from quax._compat import JAX_GE_0_7_2
 
@@ -134,3 +136,53 @@ def test_typed_complex_with_imaginary():
 
     assert arr.item() == 3j
     assert arr.dtype == np.complex64
+
+
+# ---------------------------------------------------------------------------
+# `jax.Array` faithfulness (plum dispatch caching)
+#
+# `quax._compat` marks `jax.Array` as "faithful" so that `plum` can cache method
+# resolution. Newer JAX gives `jax.Array` a custom metaclass ``__instancecheck__``
+# that `plum` would otherwise treat as non-faithful, which disables the
+# resolution cache for any `plum` function registering a `jax.Array` method --
+# including the global ``convert`` run on the return value of every dispatched
+# function. These tests guard against that regression.
+
+
+def test_jax_array_marked_faithful():
+    """`quax._compat` marks `jax.Array` faithful, and `plum` recognises it."""
+    assert getattr(jax.Array, "__faithful__", False) is True
+    assert is_faithful(jax.Array) is True
+
+
+def _convert_dispatcher():
+    """Return plum's internal ``convert`` dispatcher, or skip if relocated."""
+    try:
+        from plum.promotion import _convert
+    except ImportError:  # pragma: no cover - guards against plum internals moving
+        pytest.skip("plum's internal convert dispatcher is not importable")
+    return _convert
+
+
+def test_convert_resolver_stays_faithful():
+    """The `jax.Array` `convert` methods must not disable plum's resolver cache.
+
+    Without ``jax.Array.__faithful__ = True``, the ``TypedInt/Float/Complex ->
+    jax.Array`` conversions registered in ``quax._compat`` make plum's global
+    ``convert`` resolver non-faithful, disabling caching for every conversion.
+    """
+    convert = _convert_dispatcher()
+    # Trigger resolution of the (lazily registered) conversion methods.
+    plum.convert(jnp.asarray(1.0), jax.Array)
+    assert convert._resolver.is_faithful
+
+
+def test_convert_resolution_is_cached():
+    """A faithful resolver actually caches resolution (no re-resolve per call)."""
+    convert = _convert_dispatcher()
+    if not hasattr(convert, "clear_cache"):  # pragma: no cover
+        pytest.skip("plum.Function has no clear_cache in this version")
+    convert.clear_cache()
+    assert len(convert._cache) == 0
+    plum.convert(jnp.asarray(1.0), jax.Array)
+    assert len(convert._cache) > 0


### PR DESCRIPTION
## Summary

Newer JAX (≥0.10) gives `jax.Array` a custom metaclass `__instancecheck__`, which `plum` conservatively treats as **non-faithful** (i.e. `isinstance(x, T)` is not guaranteed to agree with `issubclass(type(x), T)`).

`plum` only caches method resolution when *every* type registered on a function is faithful — a single non-faithful type disables the resolution cache for the whole function. quax registers `convert` methods targeting `jax.Array` (the `TypedInt`/`TypedFloat`/`TypedComplex` literal converters), so this disables caching on plum's global `convert`. Because `plum` runs `convert` on the return value of **every** dispatched function that has a concrete (non-`Any`) return annotation, that uncached resolution is re-run on every call — the dominant runtime cost for any library built on `quax.ArrayValue`.

## Fix

Set `jax.Array.__faithful__ = True` (plum's official opt-in) before the `convert` methods are registered, so their signatures are built faithful and the cache is enabled.

This only gates **caching** of plum's deterministic, type-based resolution — it never changes which method is selected, so results are unchanged.

## Measurements (jax 0.10.1)

| | before | after |
|---|---|---|
| `plum.convert(arr, jax.Array)` | ~214 µs | ~2.5 µs (**~85×**) |

Downstream (e.g. `unxt`), this translates to ~4× faster arithmetic, ~10× faster construction, and 8–17× faster unit stripping/conversion.

On older JAX (<0.10) `jax.Array` was already faithful, so this is a no-op.

## Tests

Added to `tests/unit/test_jax_compat.py`:
- `test_jax_array_marked_faithful` — the attribute is set and plum's `is_faithful()` recognises it (guards removal on every JAX version).
- `test_convert_resolver_stays_faithful` — the `TypedX → jax.Array` converters do not make plum's global `convert` resolver non-faithful.
- `test_convert_resolution_is_cached` — a faithful resolver actually caches resolution (not re-run per call).

Verified these **fail without the fix** on jax 0.10.1 (and the first fails on older JAX too), and pass with it.

## Test runs

- Full quax suite, pinned env (jax 0.8.1): `981 passed`.
- quax dispatch tests under jax 0.10.1 (fix active): green.
- The identical change validated against a large downstream suite (`unxt`, jax 0.10.1): all tests green, results identical under eager/jit/grad/vmap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
